### PR TITLE
Add shell command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Learn more at [modelcontextprotocol.io](https://modelcontextprotocol.io/)
 | `/model <provider:name> default` | Set default model                |
 | `/branch <name>`                 | Create and switch Git branch     |
 | `/dump`                          | Show message history (debug)     |
+| `!`                              | Run shell command or open shell  |
 | `exit`                           | Exit application                 |
 
 ### Debug & Recovery Commands

--- a/src/tunacode/cli/repl.py
+++ b/src/tunacode/cli/repl.py
@@ -6,6 +6,8 @@ Handles user input, command processing, and agent interaction in an interactive 
 """
 
 import json
+import os
+import subprocess
 from asyncio.exceptions import CancelledError
 
 from prompt_toolkit.application import run_in_terminal
@@ -269,6 +271,19 @@ async def repl(state_manager: StateManager):
                 action = await _handle_command(line, state_manager)
                 if action == "restart":
                     break
+                continue
+
+            if line.startswith("!"):
+                command = line[1:].strip()
+
+                def run_shell():
+                    if command:
+                        subprocess.run(command, shell=True)
+                    else:
+                        shell = os.environ.get("SHELL", "bash")
+                        subprocess.run(shell)
+
+                await run_in_terminal(run_shell)
                 continue
 
             # Check if another task is already running


### PR DESCRIPTION
## Summary
- add `!` shell command support in the REPL
- document the new `!` command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_ai')*

------
https://chatgpt.com/codex/tasks/task_e_683b3da98d1483259c7cb74568133e57