### PR TITLE
Improve Ctrl+C handling

### DIFF
--- a/src/tunacode/cli/main.py
+++ b/src/tunacode/cli/main.py
@@ -14,6 +14,7 @@ from tunacode.core.state import StateManager
 from tunacode.setup import setup
 from tunacode.ui import console as ui
 from tunacode.utils.system import check_for_updates
+from tunacode.exceptions import UserAbortError
 
 app_settings = ApplicationSettings()
 app = typer.Typer(help="🐟 TunaCode - Your AI-powered development assistant")
@@ -49,6 +50,9 @@ def main(
         try:
             await setup(run_setup, state_manager, cli_config)
             await repl(state_manager)
+        except (KeyboardInterrupt, UserAbortError):
+            update_task.cancel()
+            return
         except Exception as e:
             from tunacode.exceptions import ConfigurationError
 

--- a/src/tunacode/cli/repl.py
+++ b/src/tunacode/cli/repl.py
@@ -282,6 +282,7 @@ async def process_request(text: str, state_manager: StateManager, output: bool =
 
 async def repl(state_manager: StateManager):
     action = None
+    ctrl_c_pressed = False
 
     # Professional startup information
     await ui.muted(f"• Model: {state_manager.session.current_model}")
@@ -294,11 +295,19 @@ async def repl(state_manager: StateManager):
         while True:
             try:
                 line = await ui.multiline_input(state_manager, _command_registry)
+            except UserAbortError:
+                if ctrl_c_pressed:
+                    break
+                ctrl_c_pressed = True
+                await ui.warning("Hit Ctrl+C again to exit")
+                continue
             except (EOFError, KeyboardInterrupt):
                 break
 
             if not line:
                 continue
+
+            ctrl_c_pressed = False
 
             if line.lower() in ["exit", "quit"]:
                 break


### PR DESCRIPTION
## Summary
- add global catch for `KeyboardInterrupt` and `UserAbortError`
- ctrl+C now exits without a traceback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68407d84a5d483259b0cfed7795fe687