### PR TITLE
fix: Correct pip upgrade command in setup script

### DIFF
--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -178,9 +178,11 @@ log "${GREEN}✓${NC} Virtual environment activated"
 
 # Upgrade pip, setuptools, and wheel
 log "${BLUE}Upgrading pip, setuptools, and wheel...${NC}"
-if ! install_with_retry "--upgrade pip setuptools wheel"; then
+if ! pip install --upgrade pip setuptools wheel 2>&1 | tee -a "$LOG_FILE"; then
+    log "${RED}Failed to upgrade pip, setuptools, and wheel${NC}"
     cleanup_on_failure
 fi
+log "${GREEN}✓${NC} Successfully upgraded pip, setuptools, and wheel"
 
 # Install critical dependency pydantic-ai first
 log "${BLUE}Installing critical dependency: pydantic-ai...${NC}"


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the setup script where the pip upgrade command was failing with "no such option" error.

## Problem

The setup script was incorrectly passing `"--upgrade pip setuptools wheel"` as a single argument to the `install_with_retry` function, which caused pip to interpret it as a package name rather than command options.

## Solution

Changed the pip upgrade step to use a direct `pip install --upgrade` command instead of the retry wrapper, since these core packages need special handling.

## Changes

- Fixed line 181 in `scripts/setup_dev_env.sh` to use proper pip upgrade syntax
- Added success logging after successful upgrade
- Maintained error handling and cleanup on failure

## Testing

Tested the fix locally by running the pip upgrade command in an isolated virtual environment - it completes successfully.

## User Impact

This fixes the setup script failure that users were experiencing, allowing them to properly set up their development environment.

Fixes the issue reported where users see:
```
no such option: --upgrade pip setuptools wheel
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging and error handling during the upgrade of pip, setuptools, and wheel in the development environment setup script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->