### PR TITLE
Remove unused setup agent helper

### DIFF
--- a/src/tunacode/setup.py
+++ b/src/tunacode/setup.py
@@ -5,10 +5,7 @@ Package setup and metadata configuration for the TunaCode CLI.
 Provides high-level setup functions for initializing the application and its agents.
 """
 
-from typing import Any, Optional
-
 from tunacode.core.setup import (
-    AgentSetup,
     ConfigSetup,
     EnvironmentSetup,
     SetupCoordinator,
@@ -43,19 +40,3 @@ async def setup(
     await coordinator.run_setup(force_setup=run_setup, wizard_mode=wizard_mode)
 
 
-async def setup_agent(agent: Optional[Any], state_manager: StateManager) -> None:
-    """
-    Setup the agent separately.
-
-    This is called from other parts of the codebase when an agent needs to be initialized.
-
-    Args:
-        agent: The agent instance to initialize.
-        state_manager (StateManager): The state manager instance.
-    """
-    if agent is not None:
-        agent_setup = AgentSetup(state_manager, agent)
-        if await agent_setup.should_run():
-            await agent_setup.execute()
-            if not await agent_setup.validate():
-                raise RuntimeError("Agent setup failed validation")


### PR DESCRIPTION
## Summary
- remove the unused `setup_agent` helper from `tunacode.setup`
- drop the redundant `AgentSetup` import

## Testing
- not run (not required for removing unused code)


------
https://chatgpt.com/codex/tasks/task_e_690c4b3b4f808325ad44a24b0870dced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal architecture by removing redundant agent initialization code and reducing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->