### PR TITLE
Remove unused SimpleResult type

### DIFF
--- a/src/tunacode/types.py
+++ b/src/tunacode/types.py
@@ -140,13 +140,6 @@ class FallbackResponse:
     next_steps: List[str] = field(default_factory=list)
 
 
-@dataclass
-class SimpleResult:
-    """Simple result container for agent responses."""
-
-    output: str
-
-
 class AgentState(Enum):
     """Agent loop states for enhanced completion detection."""
 


### PR DESCRIPTION
## Summary
- remove the unused SimpleResult dataclass from the shared types module to avoid duplicate definitions

## Testing
- ruff check --fix .
- PYTHONPATH=src pytest (fails: async tests require pytest-asyncio or similar plugin)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f15381e0832592c02bcf600c76d0)