### PR TITLE
Remove unused first-time user initializer

### DIFF
--- a/src/tunacode/utils/config/__init__.py
+++ b/src/tunacode/utils/config/__init__.py
@@ -2,7 +2,6 @@
 
 from tunacode.utils.config.user_configuration import (
     compute_config_fingerprint,
-    initialize_first_time_user,
     load_config,
     save_config,
     set_default_model,
@@ -10,7 +9,6 @@ from tunacode.utils.config.user_configuration import (
 
 __all__ = [
     "compute_config_fingerprint",
-    "initialize_first_time_user",
     "load_config",
     "save_config",
     "set_default_model",

--- a/src/tunacode/utils/config/user_configuration.py
+++ b/src/tunacode/utils/config/user_configuration.py
@@ -16,7 +16,6 @@ from tunacode.types import ModelName, UserConfig
 if TYPE_CHECKING:
     from tunacode.core.state import StateManager
 
-
 import hashlib
 
 _config_fingerprint = None
@@ -95,26 +94,3 @@ def _ensure_onboarding_defaults(config: UserConfig) -> None:
     """Ensure onboarding-related default settings are present in config."""
     if "settings" not in config:
         config["settings"] = {}
-
-
-def initialize_first_time_user(state_manager: "StateManager") -> None:
-    """Initialize first-time user settings and save configuration."""
-    from datetime import datetime
-
-    # Ensure settings section exists
-    if "settings" not in state_manager.session.user_config:
-        state_manager.session.user_config["settings"] = {}
-
-    settings = state_manager.session.user_config["settings"]
-
-    # Only set installation date if it doesn't exist (true first-time)
-    if "first_installation_date" not in settings:
-        settings["first_installation_date"] = datetime.now().isoformat()
-        settings["enable_tutorial"] = True
-
-        # Save the updated configuration
-        try:
-            save_config(state_manager)
-        except ConfigurationError:
-            # Non-critical error, continue without failing
-            pass


### PR DESCRIPTION
## Summary
- remove the unused `initialize_first_time_user` helper and stop exporting it from the config utilities
- keep the user configuration module focused on the currently used persistence helpers

## Testing
- ruff check .
- PYTHONPATH=src pytest *(fails: async test plugin missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934788d12108325b37002c2e8caaab6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the first-time user initialization functionality that previously configured tutorial preferences and tracked the initial installation date upon app startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->