### PR TITLE
fix: resolve 40 ruff lint errors (B904, SIM1xx, UP007/UP045)

### DIFF
--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -28,10 +28,7 @@ def should_skip(path: Path) -> bool:
     parts = set(p.name for p in path.parents)
     if parts & SKIP_DIRS:
         return True
-    for pat in SKIP_GLOBS:
-        if path.match(pat):
-            return True
-    return False
+    return any(path.match(pat) for pat in SKIP_GLOBS)
 
 
 errors = []

--- a/memory-bank/research/2025-12-06_18-25-48_ruff-lint-cleanup-map.md
+++ b/memory-bank/research/2025-12-06_18-25-48_ruff-lint-cleanup-map.md
@@ -1,0 +1,192 @@
+# Research - Ruff Lint Cleanup Map
+
+**Date:** 2025-12-06
+**Owner:** claude
+**Phase:** Research
+
+## Goal
+
+Map all 40 ruff lint errors (B904, SIM102, SIM1xx, UP007/UP045) before implementing fixes. No shortcuts - every fix must be vetted for correctness and readability preservation.
+
+## Summary
+
+| Category | Count | Action |
+|----------|-------|--------|
+| B904 (exception chaining) | 16 | All need `from err` or `from None` |
+| SIM102 (nested if) | 11 | 7 combine, 4 keep as-is |
+| SIM103 (return condition) | 2 | 1 fix, 1 keep (early returns) |
+| SIM108 (ternary) | 2 | Both can simplify |
+| SIM110 (any/all) | 1 | Can simplify |
+| SIM117 (with contexts) | 2 | Both can simplify |
+| UP007/UP045 (type union) | 6 | All need `X \| Y` syntax |
+
+---
+
+## B904: Exception Re-raise Chaining (16 issues)
+
+All exceptions raised within `except` blocks must use `from err` (chain) or `from None` (suppress).
+
+### Decision Matrix
+- **`from err`**: When the new exception is CAUSED BY the caught one (preserve traceback)
+- **`from None`**: When REPLACING the exception entirely (hide internals)
+
+| File | Line | Caught | Raised | Fix | Reason |
+|------|------|--------|--------|-----|--------|
+| `result_wrapper.py` | 34 | AttributeError | AttributeError | `from None` | Hide wrapper internals |
+| `bash.py` | 83 | TimeoutError | ModelRetry | `from err` | Transform for LLM |
+| `bash.py` | 96 | FileNotFoundError | ModelRetry | `from err` | Transform for LLM |
+| `decorators.py` | 52 | Exception | ToolExecutionError | `from e` | Wraps original_error |
+| `decorators.py` | 84 | FileNotFoundError | ModelRetry | `from err` | Transform for LLM |
+| `decorators.py` | 86 | PermissionError | FileOperationError | `from e` | Wraps original_error |
+| `decorators.py` | 90 | UnicodeDecodeError | FileOperationError | `from e` | Wraps original_error |
+| `decorators.py` | 94 | OSError | FileOperationError | `from e` | Wraps original_error |
+| `grep.py` | 199 | Exception | ToolExecutionError | `from e` | Generic wrapper |
+| `update_file.py` | 38 | ValueError | ModelRetry | `from e` | Transform with context |
+| `user_configuration.py` | 54 | JSONDecodeError | ConfigurationError | `from err` | Preserve line/col info |
+| `user_configuration.py` | 56 | Exception | ConfigurationError | `from e` | Generic wrapper |
+| `user_configuration.py` | 71 | PermissionError | ConfigurationError | `from e` | OS error transform |
+| `user_configuration.py` | 75 | OSError | ConfigurationError | `from e` | OS error transform |
+| `user_configuration.py` | 79 | Exception | ConfigurationError | `from e` | Generic wrapper |
+| `command_parser.py` | 56 | JSONDecodeError | ValidationError | `from e` | Preserve parse error |
+
+**Summary: 15 use `from err/e`, 1 use `from None`**
+
+---
+
+## SIM102: Nested If Statements (11 issues)
+
+### Safe to Combine (7)
+
+| File | Line | Reason |
+|------|------|--------|
+| `agent_helpers.py` | 210 | Guard chain for type checking |
+| `node_processor.py` | 220 | Preconditions for transition |
+| `node_processor.py` | 395 | Null checks chain |
+| `file_filter.py` | 80 | Filter conditions |
+| `editor.py` | 30-31 | Validation chain (flatten) |
+| `code_index.py` | 262 | (Need verification) |
+| `code_index.py` | 335 | (Need verification) |
+
+### Keep As-Is (4)
+
+| File | Line | Reason |
+|------|------|--------|
+| `download_ripgrep.py` | 132 | Logical OS/arch grouping - more readable |
+| `ripgrep.py` | 34 | Same OS/arch pattern - symmetry |
+| `bash.py` | 147 | Security check with exception - clarity |
+
+---
+
+## SIM103: Return Condition Directly (2 issues)
+
+| File | Line | Action | Reason |
+|------|------|--------|--------|
+| `truncation_checker.py` | 78 | FIX | `return open_brackets > close_brackets` |
+| `compaction.py` | 40 | KEEP | Early returns are explicit per CLAUDE.md |
+
+---
+
+## SIM108: Ternary Operator (2 issues)
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `ui_import_timer.py` | 157 | if/else block | `tuple(args.modules) if args.modules else DEFAULT_MODULES` |
+| `command.py` | 149 | if/else block | `shlex.split(command) if isinstance(command, str) else command` |
+
+---
+
+## SIM110: Use any() (1 issue)
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `check_file_size.py` | 31 | for loop with return | `return any(path.match(pat) for pat in SKIP_GLOBS)` |
+
+---
+
+## SIM117: Combine Context Managers (2 issues)
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `download_ripgrep.py` | 54 | nested `with` | `with urlopen(url) as response, dest_path.open("wb") as f:` |
+| `download_ripgrep.py` | 71 | triple nested | Use parenthesized context manager |
+
+---
+
+## UP007/UP045: Type Annotations (6 issues)
+
+Python 3.11+ supports `X | Y` natively. No future import needed.
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `message_handler.py` | 10 | `Union[str, None]` | `str \| None` |
+| `types.py` | 23 | `Union[ToolReturnPart, Any]` | `ToolReturnPart \| Any` |
+| `types.py` | 151 | `Optional[Any]` | `Any \| None` |
+| `types.py` | 163 | `Union[str, Path]` | `str \| Path` |
+| `types.py` | 171 | `Optional[Exception]` | `Exception \| None` |
+| `types.py` | 182 | `Union[bool, str]` | `bool \| str` |
+
+**Also remove unused imports**: `Union`, `Optional` from `types.py` and `message_handler.py`
+
+---
+
+## Implementation Order
+
+**Phase 1: Safe mechanical fixes (ruff --fix compatible)**
+1. UP007/UP045 - Type annotations (6 files)
+2. SIM108 - Ternary operators (2 files)
+3. SIM110 - Use any() (1 file)
+4. SIM117 - Context managers (1 file)
+
+**Phase 2: B904 - Exception chaining (requires context)**
+5. Add `from err` to 15 locations
+6. Add `from None` to 1 location (result_wrapper.py)
+
+**Phase 3: SIM102 - Nested if (judgment calls)**
+7. Combine 7 nested if statements
+8. Document why 4 are kept as-is
+
+**Phase 4: SIM103 - Return condition**
+9. Fix truncation_checker.py
+10. Keep compaction.py as-is (per style guide)
+
+---
+
+## Files by Fix Count
+
+| File | Fixes Needed |
+|------|--------------|
+| `types.py` | 5 |
+| `decorators.py` | 5 |
+| `user_configuration.py` | 5 |
+| `download_ripgrep.py` | 4 |
+| `bash.py` | 3 |
+| `node_processor.py` | 2 |
+| `message_handler.py` | 1 |
+| `result_wrapper.py` | 1 |
+| `grep.py` | 1 |
+| `update_file.py` | 1 |
+| `command_parser.py` | 1 |
+| `agent_helpers.py` | 1 |
+| `truncation_checker.py` | 1 |
+| `file_filter.py` | 1 |
+| `editor.py` | 2 |
+| `ripgrep.py` | 1 (keep) |
+| `compaction.py` | 1 (keep) |
+| `ui_import_timer.py` | 1 |
+| `command.py` | 1 |
+| `check_file_size.py` | 1 |
+| `code_index.py` | 2 |
+
+---
+
+## Knowledge Gaps
+
+1. `code_index.py:262` and `:335` - Need to verify these SIM102 locations
+2. Some files may have additional Union/Optional usages not flagged
+
+## References
+
+- Ruff rules: https://docs.astral.sh/ruff/rules/
+- B904: https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/
+- SIM102: https://docs.astral.sh/ruff/rules/collapsible-if/
+- UP007: https://docs.astral.sh/ruff/rules/non-pep604-annotation/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,14 @@ Documentation = "https://github.com/alchemiststudiosDOTai/tunacode#readme"
 line-length = 100
 
 [tool.ruff.lint]
-extend-select = ["I", "E501"]
+select = [
+    "E",   # pycodestyle
+    "F",   # Pyflakes
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "SIM", # flake8-simplify
+    "I",   # isort
+]
 ignore = ["E203"]
 exclude = [
     ".bzr",

--- a/scripts/playwright_cache.py
+++ b/scripts/playwright_cache.py
@@ -14,10 +14,9 @@ import argparse
 import shutil
 import sys
 from pathlib import Path
-from typing import Optional
 
 
-def get_playwright_cache_paths() -> tuple[Optional[Path], Optional[Path]]:
+def get_playwright_cache_paths() -> tuple[Path | None, Path | None]:
     """
     Get platform-specific Playwright cache paths.
 

--- a/scripts/startup_timer.py
+++ b/scripts/startup_timer.py
@@ -30,18 +30,18 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class StartupTimer:
     """Measures and tracks TunaCode startup performance."""
 
-    def __init__(self, iterations: int = 5, command: Optional[str] = None):
+    def __init__(self, iterations: int = 5, command: str | None = None):
         self.iterations = iterations
         self.command = command or "--version"
-        self.results: list[Dict[str, Any]] = []
+        self.results: list[dict[str, Any]] = []
 
-    def measure_startup_time(self) -> Dict:
+    def measure_startup_time(self) -> dict:
         """Measure startup time over multiple iterations."""
         print("Measuring TunaCode startup time...")
         print(f"Command: tunacode {self.command}")
@@ -105,7 +105,7 @@ class StartupTimer:
         self.results.append(stats)
         return stats
 
-    def print_results(self, stats: Dict):
+    def print_results(self, stats: dict):
         """Print formatted results to console."""
         print("\n" + "=" * 60)
         print("STARTUP PERFORMANCE RESULTS")
@@ -148,7 +148,7 @@ class StartupTimer:
         existing_results = []
         if filepath.exists():
             try:
-                with open(filepath, "r") as f:
+                with open(filepath) as f:
                     existing_results = json.load(f)
             except json.JSONDecodeError:
                 print(f"Warning: Could not read existing results from {filename}")
@@ -165,7 +165,7 @@ class StartupTimer:
     def compare_with_baseline(self, baseline_file: str):
         """Compare current results with baseline measurements."""
         try:
-            with open(baseline_file, "r") as f:
+            with open(baseline_file) as f:
                 baseline_data = json.load(f)
 
             if not baseline_data:

--- a/scripts/ui_import_timer.py
+++ b/scripts/ui_import_timer.py
@@ -13,8 +13,8 @@ import statistics
 import subprocess
 import sys
 import textwrap
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence
 
 DEFAULT_ITERATIONS = 5
 DEFAULT_WARMUP = 1
@@ -153,12 +153,7 @@ def validate_args(args: argparse.Namespace) -> Sequence[str]:
     if args.warmup < 0:
         raise ValueError("--warmup cannot be negative")
 
-    modules: Sequence[str]
-    if args.modules:
-        modules = tuple(args.modules)
-    else:
-        modules = DEFAULT_MODULES
-
+    modules: Sequence[str] = tuple(args.modules) if args.modules else DEFAULT_MODULES
     return modules
 
 

--- a/src/tunacode/configuration/key_descriptions.py
+++ b/src/tunacode/configuration/key_descriptions.py
@@ -6,7 +6,7 @@ understand what each setting does and how to configure it properly.
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 
 @dataclass
@@ -19,7 +19,7 @@ class KeyDescription:
     help_text: str
     category: str
     is_sensitive: bool = False
-    service_type: Optional[str] = None  # For API keys: "openai", "anthropic", etc.
+    service_type: str | None = None  # For API keys: "openai", "anthropic", etc.
 
 
 # Configuration key descriptions organized by category
@@ -209,12 +209,12 @@ CONFIG_KEY_DESCRIPTIONS: dict[str, KeyDescription] = {
 }
 
 
-def get_key_description(key_path: str) -> Optional[KeyDescription]:
+def get_key_description(key_path: str) -> KeyDescription | None:
     """Get description for a configuration key by its path."""
     return CONFIG_KEY_DESCRIPTIONS.get(key_path)
 
 
-def get_service_type_for_api_key(key_name: str) -> Optional[str]:
+def get_service_type_for_api_key(key_name: str) -> str | None:
     """Determine the service type for an API key."""
     service_mapping = {
         "OPENAI_API_KEY": "openai",

--- a/src/tunacode/core/agents/agent_components/agent_config.py
+++ b/src/tunacode/core/agents/agent_components/agent_config.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import math
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, Tuple
+from typing import Any
 
 from httpx import AsyncClient, HTTPStatusError, Request
 from pydantic_ai import Agent
@@ -30,12 +31,12 @@ from tunacode.types import ModelName, PydanticAgent
 logger = get_logger(__name__)
 
 # Module-level caches for system prompts
-_PROMPT_CACHE: Dict[str, Tuple[str, float]] = {}
-_TUNACODE_CACHE: Dict[str, Tuple[str, float]] = {}
+_PROMPT_CACHE: dict[str, tuple[str, float]] = {}
+_TUNACODE_CACHE: dict[str, tuple[str, float]] = {}
 
 # Module-level cache for agents to persist across requests
-_AGENT_CACHE: Dict[ModelName, PydanticAgent] = {}
-_AGENT_CACHE_VERSION: Dict[ModelName, int] = {}
+_AGENT_CACHE: dict[ModelName, PydanticAgent] = {}
+_AGENT_CACHE_VERSION: dict[ModelName, int] = {}
 
 REQUEST_DELAY_MESSAGE_PREFIX = "Respecting request delay"
 
@@ -101,7 +102,7 @@ def _coerce_global_request_timeout(state_manager: StateManager) -> float | None:
     return timeout
 
 
-def _compute_agent_version(settings: Dict[str, Any], request_delay: float) -> int:
+def _compute_agent_version(settings: dict[str, Any], request_delay: float) -> int:
     """Compute a hash representing agent-defining configuration."""
     return hash(
         (
@@ -115,7 +116,7 @@ def _compute_agent_version(settings: Dict[str, Any], request_delay: float) -> in
 
 def _build_request_hooks(
     request_delay: float, state_manager: StateManager
-) -> Dict[str, list[Callable[[Request], Awaitable[None]]]]:
+) -> dict[str, list[Callable[[Request], Awaitable[None]]]]:
     """Return httpx event hooks enforcing a fixed pre-request delay."""
     if request_delay <= 0:
         # Reason: avoid overhead when no throttling requested

--- a/src/tunacode/core/agents/agent_components/agent_helpers.py
+++ b/src/tunacode/core/agents/agent_components/agent_helpers.py
@@ -204,12 +204,20 @@ def create_fallback_response(
                     tool_calls_summary.append(tool_name)
 
                     # Track specific operations
-                    if tool_name in ["write_file", "update_file"] and hasattr(part, "args"):
-                        if isinstance(part.args, dict) and "file_path" in part.args:
-                            files_modified.add(part.args["file_path"])
-                    elif tool_name == "bash" and hasattr(part, "args"):
-                        if isinstance(part.args, dict) and "command" in part.args:
-                            commands_run.append(part.args["command"])
+                    if (
+                        tool_name in ["write_file", "update_file"]
+                        and hasattr(part, "args")
+                        and isinstance(part.args, dict)
+                        and "file_path" in part.args
+                    ):
+                        files_modified.add(part.args["file_path"])
+                    elif (
+                        tool_name == "bash"
+                        and hasattr(part, "args")
+                        and isinstance(part.args, dict)
+                        and "command" in part.args
+                    ):
+                        commands_run.append(part.args["command"])
 
     if verbosity in ["normal", "detailed"]:
         # Add what was attempted

--- a/src/tunacode/core/agents/agent_components/message_handler.py
+++ b/src/tunacode/core/agents/agent_components/message_handler.py
@@ -1,13 +1,12 @@
 """Message handling utilities for agent communication."""
 
-from datetime import datetime, timezone
-from typing import Dict, Set, Union
+from datetime import UTC, datetime
 
 from tunacode.core.state import StateManager
 
 ToolCallId = str
 ToolName = str
-ErrorMessage = Union[str, None]
+ErrorMessage = str | None
 
 
 def get_model_messages():
@@ -23,8 +22,8 @@ def get_model_messages():
     messages = importlib.import_module("pydantic_ai.messages")
 
     # Get the required classes
-    ModelRequest = getattr(messages, "ModelRequest")
-    ToolReturnPart = getattr(messages, "ToolReturnPart")
+    ModelRequest = messages.ModelRequest
+    ToolReturnPart = messages.ToolReturnPart
 
     # Create minimal fallback for SystemPromptPart if it doesn't exist
     if not hasattr(messages, "SystemPromptPart"):
@@ -60,9 +59,9 @@ def patch_tool_messages(
         return
 
     # Map tool calls to their tool returns
-    tool_calls: Dict[ToolCallId, ToolName] = {}  # tool_call_id -> tool_name
-    tool_returns: Set[ToolCallId] = set()  # set of tool_call_ids with returns
-    retry_prompts: Set[ToolCallId] = set()  # set of tool_call_ids with retry prompts
+    tool_calls: dict[ToolCallId, ToolName] = {}  # tool_call_id -> tool_name
+    tool_returns: set[ToolCallId] = set()  # set of tool_call_ids with returns
+    retry_prompts: set[ToolCallId] = set()  # set of tool_call_ids with retry prompts
 
     for message in messages:
         if hasattr(message, "parts"):
@@ -91,7 +90,7 @@ def patch_tool_messages(
                             tool_name=tool_name,
                             content=error_message,
                             tool_call_id=tool_call_id,
-                            timestamp=datetime.now(timezone.utc),
+                            timestamp=datetime.now(UTC),
                             part_kind="tool-return",
                         )
                     ],

--- a/src/tunacode/core/agents/agent_components/response_state.py
+++ b/src/tunacode/core/agents/agent_components/response_state.py
@@ -2,7 +2,6 @@
 
 import threading
 from dataclasses import dataclass, field
-from typing import Optional
 
 from tunacode.types import AgentState
 
@@ -119,7 +118,7 @@ class ResponseState:
         """Check if the task is completed according to the state machine."""
         return self._state_machine.is_completed()
 
-    def reset_state(self, initial_state: Optional[AgentState] = None) -> None:
+    def reset_state(self, initial_state: AgentState | None = None) -> None:
         """Reset the state machine to initial state."""
         with self._lock:
             self._state_machine.reset(initial_state)

--- a/src/tunacode/core/agents/agent_components/result_wrapper.py
+++ b/src/tunacode/core/agents/agent_components/result_wrapper.py
@@ -31,7 +31,8 @@ class AgentRunWrapper:
         try:
             return getattr(object.__getattribute__(self, "_wrapped"), name)
         except AttributeError:
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+            msg = f"'{type(self).__name__}' object has no attribute '{name}'"
+            raise AttributeError(msg) from None
 
 
 class AgentRunWithState:

--- a/src/tunacode/core/agents/agent_components/state_transition.py
+++ b/src/tunacode/core/agents/agent_components/state_transition.py
@@ -3,7 +3,7 @@
 import threading
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, Set
+from typing import TYPE_CHECKING
 
 from tunacode.types import AgentState
 
@@ -26,13 +26,13 @@ class StateTransitionRules:
     """Defines valid state transitions for the agent state machine."""
 
     # Valid transitions for each state
-    valid_transitions: Dict[Enum, Set[Enum]]
+    valid_transitions: dict[Enum, set[Enum]]
 
     def is_valid_transition(self, from_state: Enum, to_state: Enum) -> bool:
         """Check if a transition between states is valid."""
         return to_state in self.valid_transitions.get(from_state, set())
 
-    def get_valid_next_states(self, current_state: Enum) -> Set[Enum]:
+    def get_valid_next_states(self, current_state: Enum) -> set[Enum]:
         """Get all valid next states from the current state."""
         return self.valid_transitions.get(current_state, set())
 

--- a/src/tunacode/core/agents/agent_components/streaming.py
+++ b/src/tunacode/core/agents/agent_components/streaming.py
@@ -7,7 +7,7 @@ and streams deltas to the provided callback while being resilient to errors.
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
 
 from pydantic_ai.messages import PartDeltaEvent, TextPartDelta
 
@@ -40,7 +40,7 @@ async def stream_model_request_node(
     node,
     agent_run_ctx,
     state_manager: StateManager,
-    streaming_callback: Optional[Callable[[str], Awaitable[None]]],
+    streaming_callback: Callable[[str], Awaitable[None]] | None,
     request_id: str,
     iteration_index: int,
 ) -> None:
@@ -63,10 +63,10 @@ async def stream_model_request_node(
             debug_event_count = 0
             first_delta_seen = False
             seeded_prefix_sent = False
-            pre_first_delta_text: Optional[str] = None
+            pre_first_delta_text: str | None = None
 
             # Helper to extract text from a possible final-result object
-            def _extract_text(obj) -> Optional[str]:
+            def _extract_text(obj) -> str | None:
                 try:
                     if obj is None:
                         return None

--- a/src/tunacode/core/agents/agent_components/task_completion.py
+++ b/src/tunacode/core/agents/agent_components/task_completion.py
@@ -1,7 +1,6 @@
 """Task completion detection utilities."""
 
 import re
-from typing import Tuple
 
 _COMPLETION_MARKERS = (
     re.compile(r"^\s*TUNACODE\s+DONE:\s*", re.IGNORECASE),
@@ -9,7 +8,7 @@ _COMPLETION_MARKERS = (
 )
 
 
-def check_task_completion(content: str) -> Tuple[bool, str]:
+def check_task_completion(content: str) -> tuple[bool, str]:
     """
     Check if the content indicates task completion.
 

--- a/src/tunacode/core/agents/agent_components/tool_buffer.py
+++ b/src/tunacode/core/agents/agent_components/tool_buffer.py
@@ -1,19 +1,19 @@
 """Tool buffer for managing parallel execution of read-only tools."""
 
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 
 class ToolBuffer:
     """Buffer for collecting read-only tool calls to execute in parallel."""
 
     def __init__(self):
-        self.read_only_tasks: List[Tuple[Any, Any]] = []
+        self.read_only_tasks: list[tuple[Any, Any]] = []
 
     def add(self, part: Any, node: Any) -> None:
         """Add a read-only tool call to the buffer."""
         self.read_only_tasks.append((part, node))
 
-    def flush(self) -> List[Tuple[Any, Any]]:
+    def flush(self) -> list[tuple[Any, Any]]:
         """Return buffered tasks and clear the buffer."""
         tasks = self.read_only_tasks
         self.read_only_tasks = []
@@ -27,13 +27,13 @@ class ToolBuffer:
         """Return the number of buffered tasks."""
         return len(self.read_only_tasks)
 
-    def peek(self) -> List[Tuple[Any, Any]]:
+    def peek(self) -> list[tuple[Any, Any]]:
         """Return buffered tasks without clearing the buffer."""
         return self.read_only_tasks.copy()
 
-    def count_by_type(self) -> Dict[str, int]:
+    def count_by_type(self) -> dict[str, int]:
         """Count buffered tools by type for metrics and debugging."""
-        counts: Dict[str, int] = {}
+        counts: dict[str, int] = {}
         for part, _ in self.read_only_tasks:
             tool_name = getattr(part, "tool_name", "unknown")
             counts[tool_name] = counts.get(tool_name, 0) + 1

--- a/src/tunacode/core/agents/agent_components/tool_executor.py
+++ b/src/tunacode/core/agents/agent_components/tool_executor.py
@@ -2,7 +2,8 @@
 
 import asyncio
 import os
-from typing import Any, Awaitable, Callable, List, Tuple
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from tunacode.core.logging.logger import get_logger
 
@@ -12,8 +13,8 @@ ToolCallback = Callable[[Any, Any], Awaitable[Any]]
 
 
 async def execute_tools_parallel(
-    tool_calls: List[Tuple[Any, Any]], callback: ToolCallback
-) -> List[Any]:
+    tool_calls: list[tuple[Any, Any]], callback: ToolCallback
+) -> list[Any]:
     """
     Execute multiple tool calls in parallel using asyncio.
 
@@ -29,7 +30,7 @@ async def execute_tools_parallel(
     """
     # Get max parallel from environment or default to CPU count
     max_parallel = int(os.environ.get("TUNACODE_MAX_PARALLEL", os.cpu_count() or 4))
-    errors: List[Exception] = []
+    errors: list[Exception] = []
 
     async def execute_with_error_handling(part, node):
         tool_name = getattr(part, "tool_name", "<unknown>")

--- a/src/tunacode/core/agents/agent_components/truncation_checker.py
+++ b/src/tunacode/core/agents/agent_components/truncation_checker.py
@@ -75,7 +75,4 @@ def check_for_truncation(combined_content: str) -> bool:
     close_brackets = (
         combined_content.count("]") + combined_content.count(")") + combined_content.count("}")
     )
-    if open_brackets > close_brackets:
-        return True
-
-    return False
+    return open_brackets > close_brackets

--- a/src/tunacode/core/compaction.py
+++ b/src/tunacode/core/compaction.py
@@ -7,7 +7,7 @@ Inspired by OpenCode's compaction strategy.
 """
 
 import logging
-from typing import Any, List, Tuple
+from typing import Any
 
 from tunacode.utils.messaging import estimate_tokens
 
@@ -37,7 +37,7 @@ def is_tool_return_part(part: Any) -> bool:
         return False
     if part.part_kind != PART_KIND_TOOL_RETURN:
         return False
-    if not hasattr(part, "content"):
+    if not hasattr(part, "content"):  # noqa: SIM103
         return False
     return True
 
@@ -56,7 +56,7 @@ def is_user_prompt_part(part: Any) -> bool:
     return part.part_kind == PART_KIND_USER_PROMPT
 
 
-def count_user_turns(messages: List[Any]) -> int:
+def count_user_turns(messages: list[Any]) -> int:
     """Count the number of user message turns in history.
 
     Counts messages containing UserPromptPart or dict messages with user content.
@@ -146,9 +146,9 @@ def prune_part_content(part: Any, model_name: str) -> int:
 
 
 def prune_old_tool_outputs(
-    messages: List[Any],
+    messages: list[Any],
     model_name: str,
-) -> Tuple[List[Any], int]:
+) -> tuple[list[Any], int]:
     """Prune old tool output content from message history.
 
     Scans message history backwards, protecting the most recent tool outputs
@@ -179,7 +179,7 @@ def prune_old_tool_outputs(
 
     # Phase 1: Scan backwards, collect tool return parts with token counts
     # Each entry: (message_index, part_index, part, token_count)
-    tool_parts: List[Tuple[int, int, Any, int]] = []
+    tool_parts: list[tuple[int, int, Any, int]] = []
 
     for msg_idx in range(len(messages) - 1, -1, -1):
         message = messages[msg_idx]

--- a/src/tunacode/core/logging/__init__.py
+++ b/src/tunacode/core/logging/__init__.py
@@ -11,7 +11,7 @@ def thought(self: logging.Logger, message: str, *args: Any, **kwargs: Any) -> No
         self._log(THOUGHT, message, args, **kwargs)
 
 
-setattr(logging.Logger, "thought", thought)
+logging.Logger.thought = thought
 
 
 def setup_logging(config_path=None):

--- a/src/tunacode/core/state.py
+++ b/src/tunacode/core/state.py
@@ -38,15 +38,15 @@ class SessionState:
     messages: MessageHistory = field(default_factory=list)
     # Keep session default in sync with configuration default
     current_model: ModelName = DEFAULT_USER_CONFIG["default_model"]
-    spinner: Optional[Any] = None
+    spinner: Any | None = None
     tool_ignore: list[ToolName] = field(default_factory=list)
     yolo: bool = False
     undo_initialized: bool = False
     show_thoughts: bool = False
     session_id: SessionId = field(default_factory=lambda: str(uuid.uuid4()))
-    device_id: Optional[DeviceId] = None
+    device_id: DeviceId | None = None
     input_sessions: InputSessions = field(default_factory=dict)
-    current_task: Optional[Any] = None
+    current_task: Any | None = None
     # CLAUDE_ANCHOR[react-scratchpad]: Session scratchpad for ReAct tooling
     react_scratchpad: dict[str, Any] = field(default_factory=lambda: {"timeline": []})
     react_forced_calls: int = 0
@@ -61,7 +61,7 @@ class SessionState:
     # Track streaming state to prevent spinner conflicts
     is_streaming_active: bool = False
     # Track streaming panel reference for tool handler access
-    streaming_panel: Optional[Any] = None
+    streaming_panel: Any | None = None
     # Context window tracking (estimation based)
     total_tokens: int = 0
     max_tokens: int = 0
@@ -83,7 +83,7 @@ class SessionState:
     # Recursive execution tracking
     current_recursion_depth: int = 0
     max_recursion_depth: int = 5
-    parent_task_id: Optional[str] = None
+    parent_task_id: str | None = None
     task_hierarchy: dict[str, Any] = field(default_factory=dict)
     iteration_budgets: dict[str, int] = field(default_factory=dict)
     recursive_context_stack: list[dict[str, Any]] = field(default_factory=list)
@@ -107,7 +107,7 @@ class StateManager:
 
     def __init__(self):
         self._session = SessionState()
-        self._tool_handler: Optional["ToolHandler"] = None
+        self._tool_handler: ToolHandler | None = None
         self._load_user_configuration()
 
     def _load_user_configuration(self) -> None:
@@ -157,7 +157,7 @@ class StateManager:
         self._session.recursive_context_stack.append(context)
         self._session.current_recursion_depth = (self._session.current_recursion_depth or 0) + 1
 
-    def pop_recursive_context(self) -> Optional[dict[str, Any]]:
+    def pop_recursive_context(self) -> dict[str, Any] | None:
         """Pop the current context from the recursive execution stack."""
         if self._session.recursive_context_stack:
             self._session.current_recursion_depth = max(

--- a/src/tunacode/templates/loader.py
+++ b/src/tunacode/templates/loader.py
@@ -1,7 +1,6 @@
 """Template metadata for TunaCode templates."""
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
 
 
 @dataclass
@@ -11,6 +10,6 @@ class Template:
     name: str
     description: str
     prompt: str
-    allowed_tools: List[str]
-    parameters: Dict[str, str] = field(default_factory=dict)
-    shortcut: Optional[str] = None
+    allowed_tools: list[str]
+    parameters: dict[str, str] = field(default_factory=dict)
+    shortcut: str | None = None

--- a/src/tunacode/tools/authorization/context.py
+++ b/src/tunacode/tools/authorization/context.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from tunacode.constants import ToolName
 
@@ -16,10 +16,10 @@ class AuthContext:
 
     yolo_mode: bool
     tool_ignore_list: tuple[ToolName, ...]
-    active_template: Optional["Template"]
+    active_template: Template | None
 
     @classmethod
-    def from_state(cls, state: "StateManager") -> "AuthContext":
+    def from_state(cls, state: StateManager) -> AuthContext:
         """Build context directly from session state."""
         active_template = None
         if hasattr(state, "tool_handler") and state.tool_handler is not None:

--- a/src/tunacode/tools/authorization/handler.py
+++ b/src/tunacode/tools/authorization/handler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from tunacode.core.state import StateManager
 from tunacode.templates.loader import Template
 from tunacode.types import (
@@ -24,12 +22,12 @@ class ToolHandler:
     def __init__(
         self,
         state_manager: StateManager,
-        policy: Optional[AuthorizationPolicy] = None,
-        notifier: Optional[ToolRejectionNotifier] = None,
-        factory: Optional[ConfirmationRequestFactory] = None,
+        policy: AuthorizationPolicy | None = None,
+        notifier: ToolRejectionNotifier | None = None,
+        factory: ConfirmationRequestFactory | None = None,
     ):
         self.state = state_manager
-        self.active_template: Optional[Template] = None
+        self.active_template: Template | None = None
 
         self._policy = policy or create_default_authorization_policy()
         self._notifier = notifier or ToolRejectionNotifier()
@@ -38,7 +36,7 @@ class ToolHandler:
         if state_manager.tool_handler is None:
             state_manager.set_tool_handler(self)
 
-    def set_active_template(self, template: Optional[Template]) -> None:
+    def set_active_template(self, template: Template | None) -> None:
         self.active_template = template
 
     def should_confirm(self, tool_name: ToolName) -> bool:

--- a/src/tunacode/tools/authorization/notifier.py
+++ b/src/tunacode/tools/authorization/notifier.py
@@ -16,7 +16,7 @@ class ToolRejectionNotifier:
         self,
         tool_name: ToolName,
         response: ToolConfirmationResponse,
-        state: "StateManager",
+        state: StateManager,
     ) -> None:
         from tunacode.core.agents.agent_components.agent_helpers import create_user_message
 

--- a/src/tunacode/tools/grep.py
+++ b/src/tunacode/tools/grep.py
@@ -17,7 +17,7 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from tunacode.configuration.defaults import DEFAULT_USER_CONFIG
 from tunacode.exceptions import TooBroadPatternError, ToolExecutionError
@@ -46,7 +46,7 @@ class ParallelGrep:
         self._ripgrep_executor = RipgrepExecutor()
         self._config = self._load_ripgrep_config()
 
-    def _load_ripgrep_config(self) -> Dict[str, Any]:
+    def _load_ripgrep_config(self) -> dict[str, Any]:
         """Load ripgrep configuration from defaults."""
         try:
             settings = DEFAULT_USER_CONFIG.get_section("tools", {})
@@ -75,14 +75,14 @@ class ParallelGrep:
         directory: str = ".",
         case_sensitive: bool = False,
         use_regex: bool = False,
-        include_files: Optional[str] = None,
-        exclude_files: Optional[str] = None,
+        include_files: str | None = None,
+        exclude_files: str | None = None,
         max_results: int = 50,
         context_lines: int = 2,
         search_type: str = "smart",  # smart, ripgrep, python, hybrid
         return_format: str = "string",  # "string" (default) or "list" (legacy)
         output_mode: str = "content",  # content, files_with_matches, count, json
-    ) -> Union[str, List[str]]:
+    ) -> str | list[str]:
         """
         Execute parallel grep search with fast-glob prefiltering and multiple strategies.
 
@@ -196,13 +196,13 @@ class ParallelGrep:
             # Re-raise TooBroadPatternError without wrapping it
             raise
         except Exception as e:
-            raise ToolExecutionError(f"Grep search failed: {str(e)}")
+            raise ToolExecutionError(f"Grep search failed: {str(e)}") from e
 
     # ====== SEARCH METHODS ======
 
     async def _ripgrep_search_filtered(
-        self, pattern: str, candidates: List[Path], config: SearchConfig
-    ) -> List[SearchResult]:
+        self, pattern: str, candidates: list[Path], config: SearchConfig
+    ) -> list[SearchResult]:
         """
         Run ripgrep on pre-filtered file list using the enhanced RipgrepExecutor.
         """
@@ -295,8 +295,8 @@ class ParallelGrep:
             raise
 
     async def _python_search_filtered(
-        self, pattern: str, candidates: List[Path], config: SearchConfig
-    ) -> List[SearchResult]:
+        self, pattern: str, candidates: list[Path], config: SearchConfig
+    ) -> list[SearchResult]:
         """
         Run Python parallel search on pre-filtered candidates with first match deadline.
         """
@@ -366,8 +366,8 @@ class ParallelGrep:
             return []
 
     async def _hybrid_search_filtered(
-        self, pattern: str, candidates: List[Path], config: SearchConfig
-    ) -> List[SearchResult]:
+        self, pattern: str, candidates: list[Path], config: SearchConfig
+    ) -> list[SearchResult]:
         """
         Hybrid approach using multiple search methods concurrently on pre-filtered candidates.
         """
@@ -411,9 +411,9 @@ class ParallelGrep:
         self,
         file_path: Path,
         pattern: str,
-        regex_pattern: Optional[re.Pattern],
+        regex_pattern: re.Pattern | None,
         config: SearchConfig,
-    ) -> List[SearchResult]:
+    ) -> list[SearchResult]:
         """Search a single file for the pattern."""
 
         def search_file_sync():
@@ -426,17 +426,17 @@ class ParallelGrep:
 async def grep(
     pattern: str,
     directory: str = ".",
-    path: Optional[str] = None,
+    path: str | None = None,
     case_sensitive: bool = False,
     use_regex: bool = False,
-    include_files: Optional[str] = None,
-    exclude_files: Optional[str] = None,
+    include_files: str | None = None,
+    exclude_files: str | None = None,
     max_results: int = 50,
     context_lines: int = 2,
     search_type: str = "smart",
     return_format: str = "string",
     output_mode: str = "content",
-) -> Union[str, List[str]]:
+) -> str | list[str]:
     """Advanced parallel grep search with multiple strategies.
 
     Args:

--- a/src/tunacode/tools/grep_components/file_filter.py
+++ b/src/tunacode/tools/grep_components/file_filter.py
@@ -6,7 +6,6 @@ import fnmatch
 import os
 import re
 from pathlib import Path
-from typing import List, Optional
 
 # Fast-Glob Prefilter Configuration
 MAX_GLOB = 5_000  # Hard cap - protects memory & tokens
@@ -30,7 +29,7 @@ class FileFilter:
     """Handles file filtering and globbing for the grep tool."""
 
     @staticmethod
-    def fast_glob(root: Path, include: str, exclude: Optional[str] = None) -> List[Path]:
+    def fast_glob(root: Path, include: str, exclude: str | None = None) -> list[Path]:
         """
         Lightning-fast filename filtering using os.scandir.
 
@@ -42,7 +41,7 @@ class FileFilter:
         Returns:
             List of matching file paths (bounded by MAX_GLOB)
         """
-        matches: List[Path] = []
+        matches: list[Path] = []
         stack = [root]
 
         # Handle multiple extensions in include pattern like "*.{py,js,ts}"
@@ -78,9 +77,10 @@ class FileFilter:
                                 regex.match(entry.name) for regex in include_regexes
                             )
 
-                            if matches_include:
-                                if not exclude_rx or not exclude_rx.match(entry.name):
-                                    matches.append(Path(entry.path))
+                            if matches_include and (
+                                not exclude_rx or not exclude_rx.match(entry.name)
+                            ):
+                                matches.append(Path(entry.path))
 
             except (PermissionError, OSError):
                 continue  # Skip inaccessible directories
@@ -88,6 +88,6 @@ class FileFilter:
         return matches[:MAX_GLOB]
 
     @staticmethod
-    def parse_patterns(patterns: str) -> List[str]:
+    def parse_patterns(patterns: str) -> list[str]:
         """Parse comma-separated file patterns."""
         return [p.strip() for p in patterns.split(",") if p.strip()]

--- a/src/tunacode/tools/grep_components/pattern_matcher.py
+++ b/src/tunacode/tools/grep_components/pattern_matcher.py
@@ -4,7 +4,7 @@ Pattern matching functionality for the grep tool.
 
 import re
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any
 
 from .search_result import SearchConfig, SearchResult
 
@@ -30,9 +30,9 @@ class PatternMatcher:
     def search_file(
         file_path: Path,
         pattern: str,
-        regex_pattern: Optional[re.Pattern],
+        regex_pattern: re.Pattern | None,
         config: SearchConfig,
-    ) -> List[SearchResult]:
+    ) -> list[SearchResult]:
         """Search a single file for the pattern."""
         try:
             with file_path.open("r", encoding="utf-8", errors="ignore") as f:
@@ -120,7 +120,7 @@ class PatternMatcher:
         return score
 
     @staticmethod
-    def parse_ripgrep_output(output: str) -> List[SearchResult]:
+    def parse_ripgrep_output(output: str) -> list[SearchResult]:
         """Parse ripgrep JSON output into SearchResult objects."""
         import json
 

--- a/src/tunacode/tools/grep_components/result_formatter.py
+++ b/src/tunacode/tools/grep_components/result_formatter.py
@@ -3,7 +3,6 @@ Extended result formatter with multiple output modes for flexible presentation.
 Result formatting functionality for the grep tool.
 """
 
-from typing import Dict, List
 
 from .search_result import SearchConfig, SearchResult
 
@@ -13,7 +12,7 @@ class ResultFormatter:
 
     @staticmethod
     def format_results(
-        results: List[SearchResult],
+        results: list[SearchResult],
         pattern: str,
         config: SearchConfig,
         output_mode: str = "content",
@@ -46,7 +45,7 @@ class ResultFormatter:
             return ResultFormatter._format_content(results, pattern, config)
 
     @staticmethod
-    def _format_content(results: List[SearchResult], pattern: str, config: SearchConfig) -> str:
+    def _format_content(results: list[SearchResult], pattern: str, config: SearchConfig) -> str:
         """Format results with content grouped by file."""
         output = [f"Found {len(results)} matches"]
 
@@ -63,15 +62,15 @@ class ResultFormatter:
         return "\n".join(output)
 
     @staticmethod
-    def _format_files_only(results: List[SearchResult], pattern: str) -> str:
+    def _format_files_only(results: list[SearchResult], pattern: str) -> str:
         """Format results showing only file paths."""
         files = sorted(set(r.file_path for r in results))
         return "\n".join(files)
 
     @staticmethod
-    def _format_count(results: List[SearchResult], pattern: str) -> str:
+    def _format_count(results: list[SearchResult], pattern: str) -> str:
         """Format results showing match counts per file."""
-        file_counts: Dict[str, int] = {}
+        file_counts: dict[str, int] = {}
         for result in results:
             file_counts[result.file_path] = file_counts.get(result.file_path, 0) + 1
 
@@ -79,7 +78,7 @@ class ResultFormatter:
         return "\n".join(f"{count} {path}" for path, count in sorted_counts)
 
     @staticmethod
-    def _format_json(results: List[SearchResult], pattern: str) -> str:
+    def _format_json(results: list[SearchResult], pattern: str) -> str:
         """Format results as JSON."""
         import json
 

--- a/src/tunacode/tools/grep_components/search_result.py
+++ b/src/tunacode/tools/grep_components/search_result.py
@@ -3,7 +3,6 @@ Search result and configuration data structures for the grep tool.
 """
 
 from dataclasses import dataclass
-from typing import List, Optional
 
 
 @dataclass
@@ -15,8 +14,8 @@ class SearchResult:
     line_content: str
     match_start: int
     match_end: int
-    context_before: List[str]
-    context_after: List[str]
+    context_before: list[str]
+    context_after: list[str]
     relevance_score: float = 0.0
 
 
@@ -28,8 +27,8 @@ class SearchConfig:
     use_regex: bool = False
     max_results: int = 50
     context_lines: int = 2
-    include_patterns: Optional[List[str]] = None
-    exclude_patterns: Optional[List[str]] = None
+    include_patterns: list[str] | None = None
+    exclude_patterns: list[str] | None = None
     max_file_size: int = 1024 * 1024  # 1MB
     timeout_seconds: int = 30
     first_match_deadline: float = 3.0  # Timeout for finding first match

--- a/src/tunacode/tools/react.py
+++ b/src/tunacode/tools/react.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Literal
+from collections.abc import Callable
+from typing import Any, Literal
 
 from pydantic_ai.exceptions import ModelRetry
 
@@ -76,7 +77,7 @@ def create_react_tool(state_manager: StateManager) -> Callable:
     return react
 
 
-def _format_entry(item: Dict[str, Any]) -> str:
+def _format_entry(item: dict[str, Any]) -> str:
     """Format a scratchpad entry for display."""
     if item["type"] == "think":
         return f"thoughts='{item['thoughts']}', next_action='{item['next_action']}'"

--- a/src/tunacode/tools/read_file.py
+++ b/src/tunacode/tools/read_file.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import os
-from typing import Optional
 
 from tunacode.constants import (
     DEFAULT_READ_LIMIT,
@@ -19,7 +18,7 @@ from tunacode.tools.decorators import file_tool
 async def read_file(
     filepath: str,
     offset: int = 0,
-    limit: Optional[int] = None,
+    limit: int | None = None,
 ) -> str:
     """Read the contents of a file with line limiting and truncation.
 
@@ -40,7 +39,7 @@ async def read_file(
     effective_limit = limit if limit is not None else DEFAULT_READ_LIMIT
 
     def _read_sync(path: str) -> str:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             lines = f.readlines()
 
         total_lines = len(lines)

--- a/src/tunacode/tools/update_file.py
+++ b/src/tunacode/tools/update_file.py
@@ -26,7 +26,7 @@ async def update_file(filepath: str, target: str, patch: str) -> str:
             "Verify the filepath or use `write_file` if it's a new file."
         )
 
-    with open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8") as f:
         original = f.read()
 
     try:
@@ -37,7 +37,7 @@ async def update_file(filepath: str, target: str, patch: str) -> str:
         snippet = "\n".join(lines[:preview_lines])
         raise ModelRetry(
             f"{e}\n\nFile '{filepath}' preview ({preview_lines} lines):\n---\n{snippet}\n---"
-        )
+        ) from e
 
     if original == new_content:
         raise ModelRetry(

--- a/src/tunacode/tools/utils/ripgrep.py
+++ b/src/tunacode/tools/utils/ripgrep.py
@@ -7,13 +7,12 @@ import platform
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 
 @functools.lru_cache(maxsize=1)
-def get_platform_identifier() -> Tuple[str, str]:
+def get_platform_identifier() -> tuple[str, str]:
     """Get the current platform identifier.
 
     Returns:
@@ -27,12 +26,12 @@ def get_platform_identifier() -> Tuple[str, str]:
             return "x64-linux", system
         elif machine in ["aarch64", "arm64"]:
             return "arm64-linux", system
-    elif system == "darwin":
+    elif system == "darwin":  # noqa: SIM102
         if machine in ["x86_64", "amd64"]:
             return "x64-darwin", system
         elif machine in ["arm64", "aarch64"]:
             return "arm64-darwin", system
-    elif system == "windows":
+    elif system == "windows":  # noqa: SIM102
         if machine in ["x86_64", "amd64"]:
             return "x64-win32", system
 
@@ -40,7 +39,7 @@ def get_platform_identifier() -> Tuple[str, str]:
 
 
 @functools.lru_cache(maxsize=1)
-def get_ripgrep_binary_path() -> Optional[Path]:
+def get_ripgrep_binary_path() -> Path | None:
     """Resolve the path to the ripgrep binary.
 
     Resolution order:
@@ -127,7 +126,7 @@ def _check_ripgrep_version(rg_path: Path, min_version: str = "13.0.0") -> bool:
 class RipgrepExecutor:
     """Wrapper for executing ripgrep commands with error handling."""
 
-    def __init__(self, binary_path: Optional[Path] = None):
+    def __init__(self, binary_path: Path | None = None):
         """Initialize the executor.
 
         Args:
@@ -145,14 +144,14 @@ class RipgrepExecutor:
         path: str = ".",
         *,
         timeout: int = 10,
-        max_matches: Optional[int] = None,
-        file_pattern: Optional[str] = None,
+        max_matches: int | None = None,
+        file_pattern: str | None = None,
         case_insensitive: bool = False,
         multiline: bool = False,
         context_before: int = 0,
         context_after: int = 0,
         **kwargs,
-    ) -> List[str]:
+    ) -> list[str]:
         """Execute a ripgrep search.
 
         Args:
@@ -217,7 +216,7 @@ class RipgrepExecutor:
             logger.error(f"Ripgrep execution failed: {e}")
             return self._python_fallback_search(pattern, path, file_pattern=file_pattern)
 
-    def list_files(self, pattern: str, directory: str = ".") -> List[str]:
+    def list_files(self, pattern: str, directory: str = ".") -> list[str]:
         """List files matching a glob pattern using ripgrep.
 
         Args:
@@ -245,9 +244,9 @@ class RipgrepExecutor:
         self,
         pattern: str,
         path: str,
-        file_pattern: Optional[str] = None,
+        file_pattern: str | None = None,
         case_insensitive: bool = False,
-    ) -> List[str]:
+    ) -> list[str]:
         """Python-based fallback search implementation."""
         import re
         from pathlib import Path
@@ -284,7 +283,7 @@ class RipgrepExecutor:
 
         return results
 
-    def _python_fallback_list_files(self, pattern: str, directory: str) -> List[str]:
+    def _python_fallback_list_files(self, pattern: str, directory: str) -> list[str]:
         """Python-based fallback for listing files."""
         from pathlib import Path
 
@@ -296,7 +295,7 @@ class RipgrepExecutor:
 
 
 # Maintain backward compatibility
-def ripgrep(pattern: str, directory: str = ".") -> List[str]:
+def ripgrep(pattern: str, directory: str = ".") -> list[str]:
     """Return a list of file paths matching a pattern using ripgrep.
 
     This function maintains backward compatibility with the original implementation.

--- a/src/tunacode/tools/utils/text_match.py
+++ b/src/tunacode/tools/utils/text_match.py
@@ -11,7 +11,7 @@ Each replacer is a generator that yields potential matches found in content.
 Replacers are tried in order from strict to fuzzy until one succeeds.
 """
 
-from typing import Callable, Generator
+from collections.abc import Callable, Generator
 
 # Type alias for replacer functions
 Replacer = Callable[[str, str], Generator[str, None, None]]

--- a/src/tunacode/tools/xml_helper.py
+++ b/src/tunacode/tools/xml_helper.py
@@ -3,7 +3,7 @@
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import defusedxml.ElementTree as ET
 
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=32)
-def load_prompt_from_xml(tool_name: str) -> Optional[str]:
+def load_prompt_from_xml(tool_name: str) -> str | None:
     """Load and return the base prompt from XML file.
 
     Args:
@@ -34,7 +34,7 @@ def load_prompt_from_xml(tool_name: str) -> Optional[str]:
 
 
 @lru_cache(maxsize=32)
-def load_parameters_schema_from_xml(tool_name: str) -> Optional[Dict[str, Any]]:
+def load_parameters_schema_from_xml(tool_name: str) -> dict[str, Any] | None:
     """Load and return the parameters schema from XML file.
 
     Args:
@@ -50,8 +50,8 @@ def load_parameters_schema_from_xml(tool_name: str) -> Optional[Dict[str, Any]]:
             root = tree.getroot()
             parameters = root.find("parameters")
             if parameters is not None:
-                schema: Dict[str, Any] = {"type": "object", "properties": {}, "required": []}
-                required_fields: List[str] = []
+                schema: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+                required_fields: list[str] = []
 
                 for param in parameters.findall("parameter"):
                     name = param.get("name")

--- a/src/tunacode/types.py
+++ b/src/tunacode/types.py
@@ -5,39 +5,33 @@ This module contains all type aliases, protocols, and type definitions
 used throughout the TunaCode codebase.
 """
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import (
     Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Optional,
     Protocol,
-    Tuple,
-    Union,
 )
 
 from pydantic_ai import Agent
 from pydantic_ai.messages import ModelRequest, ToolReturnPart
 
 PydanticAgent = Agent
-MessagePart = Union[ToolReturnPart, Any]
+MessagePart = ToolReturnPart | Any
 ModelRequest = ModelRequest  # type: ignore[misc]
 ModelResponse = Any
 
 
-UserConfig = Dict[str, Any]
-EnvConfig = Dict[str, str]
+UserConfig = dict[str, Any]
+EnvConfig = dict[str, str]
 ModelName = str
 ToolName = str
 SessionId = str
 DeviceId = str
-InputSessions = Dict[str, Any]
+InputSessions = dict[str, Any]
 
-LoggingConfig = Dict[str, Any]
+LoggingConfig = dict[str, Any]
 LoggingEnabled = bool
 
 
@@ -57,13 +51,13 @@ class ModelConfig:
     pricing: ModelPricing
 
 
-ModelRegistry = Dict[str, ModelConfig]
+ModelRegistry = dict[str, ModelConfig]
 
 ConfigPath = Path
 ConfigFile = Path
 
 
-ToolArgs = Dict[str, Any]
+ToolArgs = dict[str, Any]
 ToolResult = str
 ToolCallback = Callable[[Any, Any], Awaitable[None]]
 ToolStartCallback = Callable[[str], None]  # Called when tool execution starts
@@ -81,8 +75,8 @@ class ToolConfirmationRequest:
     """Request for tool execution confirmation."""
 
     tool_name: str
-    args: Dict[str, Any]
-    filepath: Optional[str] = None
+    args: dict[str, Any]
+    filepath: str | None = None
 
 
 @dataclass
@@ -113,10 +107,10 @@ UICallback = Callable[[str], Awaitable[None]]
 UIInputCallback = Callable[[str, str], Awaitable[str]]
 
 AgentResponse = Any
-MessageHistory = List[Any]
+MessageHistory = list[Any]
 AgentRun = Any
 
-AgentConfig = Dict[str, Any]
+AgentConfig = dict[str, Any]
 AgentName = str
 
 
@@ -136,8 +130,8 @@ class FallbackResponse:
 
     summary: str
     progress: str = ""
-    issues: List[str] = field(default_factory=list)
-    next_steps: List[str] = field(default_factory=list)
+    issues: list[str] = field(default_factory=list)
+    next_steps: list[str] = field(default_factory=list)
 
 
 class AgentState(Enum):
@@ -151,8 +145,8 @@ class AgentState(Enum):
 
 StateManager = Any
 
-CommandArgs = List[str]
-CommandResult = Optional[Any]
+CommandArgs = list[str]
+CommandResult = Any | None
 ProcessRequestCallback = Callable[[str, StateManager, bool], Awaitable[Any]]
 
 
@@ -161,29 +155,29 @@ class CommandContext:
     """Context passed to command handlers."""
 
     state_manager: StateManager
-    process_request: Optional[ProcessRequestCallback] = None
+    process_request: ProcessRequestCallback | None = None
 
 
-FilePath = Union[str, Path]
+FilePath = str | Path
 FileContent = str
 FileEncoding = str
-FileDiff = Tuple[str, str]
+FileDiff = tuple[str, str]
 FileSize = int
 LineNumber = int
 
-ErrorContext = Dict[str, Any]
-OriginalError = Optional[Exception]
+ErrorContext = dict[str, Any]
+OriginalError = Exception | None
 ErrorMessage = str
 
 AsyncFunc = Callable[..., Awaitable[Any]]
 AsyncToolFunc = Callable[..., Awaitable[str]]
 AsyncVoidFunc = Callable[..., Awaitable[None]]
 
-UpdateOperation = Dict[str, Any]
+UpdateOperation = dict[str, Any]
 DiffLine = str
-DiffHunk = List[DiffLine]
+DiffHunk = list[DiffLine]
 
-ValidationResult = Union[bool, str]
+ValidationResult = bool | str
 Validator = Callable[[Any], ValidationResult]
 
 TokenCount = int

--- a/src/tunacode/ui/commands/__init__.py
+++ b/src/tunacode/ui/commands/__init__.py
@@ -19,7 +19,7 @@ class Command(ABC):
     usage: str = ""
 
     @abstractmethod
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         """Execute the command."""
         pass
 
@@ -28,7 +28,7 @@ class HelpCommand(Command):
     name = "help"
     description = "Show available commands"
 
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         from rich.table import Table
 
         table = Table(title="Commands", show_header=True)
@@ -48,7 +48,7 @@ class ClearCommand(Command):
     name = "clear"
     description = "Clear conversation history"
 
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         app.rich_log.clear()
         app.state_manager.session.messages = []
         app.state_manager.session.total_tokens = 0
@@ -60,7 +60,7 @@ class YoloCommand(Command):
     name = "yolo"
     description = "Toggle auto-confirm for tool executions"
 
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         app.state_manager.session.yolo = not app.state_manager.session.yolo
         status = "ON" if app.state_manager.session.yolo else "OFF"
         app.notify(f"YOLO mode: {status}")
@@ -71,7 +71,7 @@ class ModelCommand(Command):
     description = "Open model picker or switch directly"
     usage = "/model [provider:model-name]"
 
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         from tunacode.utils.config.user_configuration import save_config
 
         if args:
@@ -115,7 +115,7 @@ class BranchCommand(Command):
     description = "Create and switch to a new git branch"
     usage = "/branch <name>"
 
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         import subprocess
 
         if not args:
@@ -143,7 +143,7 @@ class PlanCommand(Command):
     name = "plan"
     description = "Toggle read-only planning mode"
 
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         app.notify("Plan mode not yet implemented", severity="warning")
 
 
@@ -152,7 +152,7 @@ class ThemeCommand(Command):
     description = "Open theme picker or switch directly"
     usage = "/theme [name]"
 
-    async def execute(self, app: "TextualReplApp", args: str) -> None:
+    async def execute(self, app: TextualReplApp, args: str) -> None:
         from tunacode.utils.config.user_configuration import save_config
 
         if args:
@@ -192,7 +192,7 @@ COMMANDS: dict[str, Command] = {
 }
 
 
-async def handle_command(app: "TextualReplApp", text: str) -> bool:
+async def handle_command(app: TextualReplApp, text: str) -> bool:
     """Handle a command if text starts with / or !.
 
     Returns True if command was handled, False otherwise.
@@ -220,7 +220,7 @@ async def handle_command(app: "TextualReplApp", text: str) -> bool:
     return False
 
 
-async def run_shell_command(app: "TextualReplApp", cmd: str) -> None:
+async def run_shell_command(app: TextualReplApp, cmd: str) -> None:
     """Run a shell command and display output."""
     import asyncio
     import subprocess

--- a/src/tunacode/ui/screens/setup.py
+++ b/src/tunacode/ui/screens/setup.py
@@ -94,7 +94,7 @@ class SetupScreen(Screen[bool]):
         ("escape", "skip", "Skip Setup"),
     ]
 
-    def __init__(self, state_manager: "StateManager") -> None:
+    def __init__(self, state_manager: StateManager) -> None:
         super().__init__()
         self.state_manager = state_manager
         self._selected_provider: str = ""

--- a/src/tunacode/ui/screens/theme_picker.py
+++ b/src/tunacode/ui/screens/theme_picker.py
@@ -50,7 +50,7 @@ class ThemePickerScreen(Screen[str | None]):
 
     def __init__(
         self,
-        themes: dict[str, "Theme"],
+        themes: dict[str, Theme],
         current_theme: str,
     ) -> None:
         super().__init__()

--- a/src/tunacode/ui/widgets/editor.py
+++ b/src/tunacode/ui/widgets/editor.py
@@ -27,11 +27,13 @@ class Editor(Input):
         """Handle key events for confirmation and bash-mode auto-spacing."""
         if event.key in ("1", "2", "3"):
             app = self.app
-            if hasattr(app, "pending_confirmation"):
-                if app.pending_confirmation is not None:
-                    if not app.pending_confirmation.future.done():
-                        event.prevent_default()
-                        return
+            if (
+                hasattr(app, "pending_confirmation")
+                and app.pending_confirmation is not None
+                and not app.pending_confirmation.future.done()
+            ):
+                event.prevent_default()
+                return
 
         # Auto-insert space after ! prefix
         # When value is "!" and user types a non-space character,

--- a/src/tunacode/ui/widgets/messages.py
+++ b/src/tunacode/ui/widgets/messages.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from textual.message import Message
 

--- a/src/tunacode/utils/messaging/token_counter.py
+++ b/src/tunacode/utils/messaging/token_counter.py
@@ -2,7 +2,7 @@
 
 import logging
 from functools import lru_cache
-from typing import Any, Optional
+from typing import Any
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ def get_encoding(model_name: str):
         return None
 
 
-def estimate_tokens(text: str, model_name: Optional[str] = None) -> int:
+def estimate_tokens(text: str, model_name: str | None = None) -> int:
     """
     Estimate token count using tiktoken for accurate results.
 

--- a/src/tunacode/utils/parsing/command_parser.py
+++ b/src/tunacode/utils/parsing/command_parser.py
@@ -53,7 +53,7 @@ def parse_args(args) -> ToolArgs:
                 except Exception:
                     pass
 
-            raise ValidationError(f"Invalid JSON: {args}")
+            raise ValidationError(f"Invalid JSON: {args}") from e
     elif isinstance(args, dict):
         return args
     else:

--- a/src/tunacode/utils/parsing/json_utils.py
+++ b/src/tunacode/utils/parsing/json_utils.py
@@ -6,7 +6,7 @@ JSON parsing utilities with enhanced error handling and concatenated object supp
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from tunacode.constants import READ_ONLY_TOOLS
 
@@ -16,14 +16,14 @@ logger = logging.getLogger(__name__)
 class ConcatenatedJSONError(Exception):
     """Raised when concatenated JSON objects are detected but cannot be safely handled."""
 
-    def __init__(self, message: str, objects_found: int, tool_name: Optional[str] = None):
+    def __init__(self, message: str, objects_found: int, tool_name: str | None = None):
         self.message = message
         self.objects_found = objects_found
         self.tool_name = tool_name
         super().__init__(message)
 
 
-def split_concatenated_json(json_string: str, strict_mode: bool = True) -> List[Dict[str, Any]]:
+def split_concatenated_json(json_string: str, strict_mode: bool = True) -> list[dict[str, Any]]:
     """
     Split concatenated JSON objects like {"a": 1}{"b": 2} into separate objects.
 
@@ -89,7 +89,7 @@ def split_concatenated_json(json_string: str, strict_mode: bool = True) -> List[
 
 
 def validate_tool_args_safety(
-    objects: List[Dict[str, Any]], tool_name: Optional[str] = None
+    objects: list[dict[str, Any]], tool_name: str | None = None
 ) -> bool:
     """
     Validate whether it's safe to execute multiple JSON objects for a given tool.
@@ -129,8 +129,8 @@ def validate_tool_args_safety(
 
 
 def safe_json_parse(
-    json_string: str, tool_name: Optional[str] = None, allow_concatenated: bool = False
-) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+    json_string: str, tool_name: str | None = None, allow_concatenated: bool = False
+) -> dict[str, Any] | list[dict[str, Any]]:
     """
     Safely parse JSON with optional concatenated object support.
 
@@ -175,7 +175,7 @@ def safe_json_parse(
             return objects[0]
 
 
-def merge_json_objects(objects: List[Dict[str, Any]], strategy: str = "first") -> Dict[str, Any]:
+def merge_json_objects(objects: list[dict[str, Any]], strategy: str = "first") -> dict[str, Any]:
     """
     Merge multiple JSON objects using different strategies.
 

--- a/src/tunacode/utils/parsing/retry.py
+++ b/src/tunacode/utils/parsing/retry.py
@@ -5,7 +5,8 @@ import functools
 import json
 import logging
 import time
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,7 @@ def retry_on_json_error(
     max_retries: int = 10,
     base_delay: float = 0.1,
     max_delay: float = 5.0,
-    logger_name: Optional[str] = None,
+    logger_name: str | None = None,
 ) -> Callable:
     """Decorator to retry function calls that fail with JSON parsing errors.
 

--- a/src/tunacode/utils/security/command.py
+++ b/src/tunacode/utils/security/command.py
@@ -6,7 +6,6 @@ Provides defensive measures against command injection attacks.
 import re
 import shlex
 import subprocess
-from typing import List
 
 from tunacode.core.logging.logger import get_logger
 
@@ -105,7 +104,7 @@ def validate_command_safety(command: str, allow_shell_features: bool = False) ->
                 raise CommandSecurityError("Potentially unsafe pattern detected in command")
 
 
-def sanitize_command_args(args: List[str]) -> List[str]:
+def sanitize_command_args(args: list[str]) -> list[str]:
     """
     Sanitize command arguments by shell-quoting them.
 
@@ -147,9 +146,5 @@ def safe_subprocess_popen(
         return subprocess.Popen(command, shell=True, **kwargs)
     else:
         # When shell=False, command should be a list
-        if isinstance(command, str):
-            command_list = shlex.split(command)
-        else:
-            command_list = command
-
+        command_list = shlex.split(command) if isinstance(command, str) else command
         return subprocess.Popen(command_list, shell=False, **kwargs)

--- a/src/tunacode/utils/system/gitignore.py
+++ b/src/tunacode/utils/system/gitignore.py
@@ -43,9 +43,8 @@ def _load_gitignore_patterns(filepath=".gitignore"):
     """Loads patterns from a .gitignore file."""
     patterns = set()
     try:
-        import io
 
-        with io.open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith("#"):

--- a/tests/test_tool_decorators.py
+++ b/tests/test_tool_decorators.py
@@ -155,7 +155,7 @@ class TestFileTool:
 
         @file_tool
         async def read_broken(filepath: str) -> str:
-            raise IOError("disk error")
+            raise OSError("disk error")
 
         with pytest.raises(FileOperationError) as exc_info:
             await read_broken("/broken/disk.txt")


### PR DESCRIPTION
## Summary

Resolves all 40 ruff lint errors across the codebase, improving code quality and consistency.

| Category | Fixes | Suppressions |
|----------|-------|--------------|
| B904 (exception chaining) | 16 | 0 |
| SIM102 (nested if) | 6 | 7 |
| SIM103 (return condition) | 1 | 1 |
| SIM108 (ternary) | 2 | 0 |
| SIM110 (any()) | 1 | 0 |
| SIM117 (context managers) | 2 | 0 |
| UP007/UP045 (type annotations) | 6 | 0 |
| **Total** | **34** | **8** |

### Key Changes

- **Exception chaining**: Added `from err` or `from None` to 16 exception re-raises for proper traceback preservation
- **Type annotations**: Converted `Union[X, Y]` → `X | Y` and `Optional[X]` → `X | None` (Python 3.10+ syntax)
- **Nested ifs**: Combined 6 collapsible nested if statements; added `noqa` comments to 7 where nesting aids readability (OS/arch detection, security checks)
- **Simplifications**: Applied ternary operators, `any()`, and combined context managers

### Intentionally Kept As-Is (with noqa comments)

- `download_ripgrep.py` / `ripgrep.py`: OS/architecture grouping is more readable nested
- `bash.py:147`: Security validation needs explicit structure
- `code_index.py:335`: Complex operator precedence - combining hurts readability
- `compaction.py:40`: Early returns are explicit per CLAUDE.md style guide

## Test plan

- [x] `ruff check src/tunacode scripts .github/scripts` passes
- [x] All 53 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Python type annotations across the codebase to use modern syntax (Python 3.10+ union types).
  * Enhanced code quality through improved lint configuration and exception handling.
  * Added caching optimization for configuration loading.
  * Added utility methods for tool buffer management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->