### PR TITLE
Remove unused XML schema loader

### DIFF
--- a/src/tunacode/tools/xml_helper.py
+++ b/src/tunacode/tools/xml_helper.py
@@ -3,7 +3,6 @@
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
 
 import defusedxml.ElementTree as ET
 
@@ -33,51 +32,3 @@ def load_prompt_from_xml(tool_name: str) -> str | None:
     return None
 
 
-@lru_cache(maxsize=32)
-def load_parameters_schema_from_xml(tool_name: str) -> dict[str, Any] | None:
-    """Load and return the parameters schema from XML file.
-
-    Args:
-        tool_name: Name of the tool (e.g., 'grep', 'glob')
-
-    Returns:
-        Dict containing the JSON schema for tool parameters or None if not found
-    """
-    try:
-        prompt_file = Path(__file__).parent / "prompts" / f"{tool_name}_prompt.xml"
-        if prompt_file.exists():
-            tree = ET.parse(prompt_file)
-            root = tree.getroot()
-            parameters = root.find("parameters")
-            if parameters is not None:
-                schema: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
-                required_fields: list[str] = []
-
-                for param in parameters.findall("parameter"):
-                    name = param.get("name")
-                    required = param.get("required", "false").lower() == "true"
-                    param_type = param.find("type")
-                    description = param.find("description")
-
-                    if name and param_type is not None:
-                        prop = {
-                            "type": param_type.text.strip(),
-                            "description": description.text.strip()
-                            if description is not None
-                            else "",
-                        }
-
-                        # Add enum values if present
-                        enums = param.findall("enum")
-                        if enums:
-                            prop["enum"] = [e.text.strip() for e in enums]
-
-                        schema["properties"][name] = prop
-                        if required:
-                            required_fields.append(name)
-
-                schema["required"] = required_fields
-                return schema
-    except Exception as e:
-        logger.warning(f"Failed to load parameters from XML for {tool_name}: {e}")
-    return None


### PR DESCRIPTION
## Summary
- remove the unused XML parameter schema loader helper
- simplify the XML helper module to only load tool prompts

## Testing
- ruff check src/tunacode/tools/xml_helper.py
- pytest tests/test_tool_decorators.py *(fails: ModuleNotFoundError: No module named 'tunacode')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935963a54788325acc0d57735de0a1d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code optimization and cleanup to improve maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->