### PR TITLE
Remove unused security constants

### DIFF
--- a/src/tunacode/utils/security/__init__.py
+++ b/src/tunacode/utils/security/__init__.py
@@ -1,8 +1,6 @@
 """Security utilities: command validation and safe execution."""
 
 from tunacode.utils.security.command import (
-    DANGEROUS_CHARS,
-    INJECTION_PATTERNS,
     CommandSecurityError,
     safe_subprocess_popen,
     sanitize_command_args,
@@ -10,8 +8,6 @@ from tunacode.utils.security.command import (
 )
 
 __all__ = [
-    "DANGEROUS_CHARS",
-    "INJECTION_PATTERNS",
     "CommandSecurityError",
     "safe_subprocess_popen",
     "sanitize_command_args",

--- a/src/tunacode/utils/security/command.py
+++ b/src/tunacode/utils/security/command.py
@@ -11,38 +11,6 @@ from tunacode.core.logging.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Dangerous shell metacharacters that indicate potential injection
-DANGEROUS_CHARS = [
-    ";",
-    "&",
-    "|",
-    "`",
-    "$",
-    "(",
-    ")",
-    "{",
-    "}",
-    "<",
-    ">",
-    "\n",
-    "\r",
-    "\\",
-    '"',
-    "'",
-]
-
-# Common injection patterns
-INJECTION_PATTERNS = [
-    r";\s*\w+",  # Command chaining with semicolon
-    r"&&\s*\w+",  # Command chaining with &&
-    r"\|\s*\w+",  # Piping to another command
-    r"`[^`]+`",  # Command substitution with backticks
-    r"\$\([^)]+\)",  # Command substitution with $()
-    r">\s*[/\w]",  # Output redirection
-    r"<\s*[/\w]",  # Input redirection
-]
-
-
 class CommandSecurityError(Exception):
     """Raised when a command fails security validation."""
 


### PR DESCRIPTION
## Summary
- remove unused security constant lists from the command validation module
- align security utilities exports with the active API

## Testing
- ruff check .
- PYTHONPATH=src pytest *(fails: async def tests need an async pytest plugin in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ff87b0d88325aa18c7e1c9e7ffa1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal security validation implementation by consolidating pattern definitions.
  * Reduced the public API surface of the security module by removing unnecessary exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->