### PR TITLE
Add write_file preview in confirmation dialog

### DIFF
--- a/src/tunacode/tools/authorization/requests.py
+++ b/src/tunacode/tools/authorization/requests.py
@@ -6,6 +6,34 @@ import os
 from tunacode.tools.utils.text_match import replace
 from tunacode.types import ToolArgs, ToolConfirmationRequest, ToolName
 
+MAX_PREVIEW_LINES = 100
+
+
+def _generate_creation_diff(filepath: str, content: str) -> str:
+    """Generate a unified diff for new file creation."""
+    lines = content.splitlines(keepends=True)
+    total_lines = len(lines)
+
+    truncated = total_lines > MAX_PREVIEW_LINES
+    if truncated:
+        lines = lines[:MAX_PREVIEW_LINES]
+
+    diff_parts = [
+        "--- /dev/null\n",
+        f"+++ b/{filepath}\n",
+        f"@@ -0,0 +1,{len(lines)} @@\n",
+    ]
+
+    for line in lines:
+        if not line.endswith("\n"):
+            line += "\n"
+        diff_parts.append(f"+{line}")
+
+    if truncated:
+        diff_parts.append(f"\n... ({total_lines - MAX_PREVIEW_LINES} more lines)\n")
+
+    return "".join(diff_parts)
+
 
 class ConfirmationRequestFactory:
     """Create structured confirmation requests for UI surfaces."""
@@ -38,6 +66,11 @@ class ConfirmationRequestFactory:
                 except Exception:
                     # If anything fails (file read, fuzzy match, etc), we just don't show the diff
                     pass
+
+        elif tool_name == "write_file" and filepath:
+            content = args.get("content", "")
+            if content:
+                diff_content = _generate_creation_diff(filepath, content)
 
         return ToolConfirmationRequest(
             tool_name=tool_name, args=args, filepath=filepath, diff_content=diff_content


### PR DESCRIPTION
## Summary
- Add diff preview for `write_file` operations in the confirmation dialog
- Previously, `write_file` only showed truncated args (57 chars) with no way to review file content
- Now shows a unified diff from `/dev/null` matching `update_file` behavior

## Test plan
- [ ] Run tunacode and ask the agent to create a new file
- [ ] Verify the confirmation dialog shows a diff preview of the content
- [ ] Verify large files (>100 lines) are truncated with a message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
* File creation confirmations now display content previews with automatic line limits (100 lines maximum) and truncation indicators for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->