### PR TITLE
feat(#151): added slash command autocompletion to TUI

### DIFF
--- a/src/tunacode/ui/app.py
+++ b/src/tunacode/ui/app.py
@@ -47,6 +47,7 @@ from tunacode.ui.styles import (
     STYLE_WARNING,
 )
 from tunacode.ui.widgets import (
+    CommandAutoComplete,
     Editor,
     EditorSubmitRequested,
     FileAutoComplete,
@@ -112,6 +113,7 @@ class TextualReplApp(App[None]):
             yield self.loading_indicator
         yield self.editor
         yield FileAutoComplete(self.editor)
+        yield CommandAutoComplete(self.editor)
         yield self.status_bar
 
     def on_mount(self) -> None:

--- a/src/tunacode/ui/widgets/__init__.py
+++ b/src/tunacode/ui/widgets/__init__.py
@@ -1,5 +1,6 @@
 """Textual widgets for TunaCode REPL."""
 
+from .command_autocomplete import CommandAutoComplete
 from .editor import Editor
 from .file_autocomplete import FileAutoComplete
 from .messages import (
@@ -11,6 +12,7 @@ from .resource_bar import ResourceBar
 from .status_bar import StatusBar
 
 __all__ = [
+    "CommandAutoComplete",
     "Editor",
     "EditorCompletionsAvailable",
     "EditorSubmitRequested",

--- a/src/tunacode/ui/widgets/command_autocomplete.py
+++ b/src/tunacode/ui/widgets/command_autocomplete.py
@@ -1,0 +1,62 @@
+"""Slash command autocomplete dropdown widget."""
+
+from __future__ import annotations
+
+from textual.widgets import Input
+from textual_autocomplete import AutoComplete, DropdownItem, TargetState
+
+from tunacode.ui.commands import COMMANDS
+
+# Pre-compute sorted command items at module load (8 items)
+_COMMAND_ITEMS: list[tuple[str, str]] = sorted(
+    [(name, cmd.description) for name, cmd in COMMANDS.items()]
+)
+
+
+class CommandAutoComplete(AutoComplete):
+    """Real-time / command autocomplete dropdown."""
+
+    def __init__(self, target: Input) -> None:
+        super().__init__(target)
+
+    def get_search_string(self, target_state: TargetState) -> str:
+        """Extract text after / symbol at start of input."""
+        text = target_state.text
+        if not text.startswith("/"):
+            return ""
+
+        prefix = text[1 : target_state.cursor_position]
+        return "" if " " in prefix else prefix
+
+    def should_show_dropdown(self, search_string: str) -> bool:  # noqa: ARG002
+        """Show dropdown only while typing command (before space)."""
+        del search_string
+        if self.option_list.option_count == 0:
+            return False
+        # Hide once user has typed a space (command complete, now typing args)
+        target_state = self._get_target_state()
+        if not target_state.text.startswith("/"):
+            return False
+        # Check if there's a space before cursor (command already entered)
+        prefix = target_state.text[1 : target_state.cursor_position]
+        return " " not in prefix
+
+    def get_candidates(self, target_state: TargetState) -> list[DropdownItem]:
+        """Return command candidates for current search."""
+        if not target_state.text.startswith("/"):
+            return []
+
+        search = self.get_search_string(target_state).lower()
+        return [
+            DropdownItem(main=f"/{name} - {desc}")
+            for name, desc in _COMMAND_ITEMS
+            if name.startswith(search)
+        ]
+
+    def apply_completion(self, value: str, state: TargetState) -> None:
+        """Replace /command region with completed value, always add trailing space."""
+        command = value.split(" - ", 1)[0]  # Extracts "/model" from "/model - description"
+        trailing = state.text[state.cursor_position :].lstrip()
+        new_text = command + " " + trailing
+        self.target.value = new_text
+        self.target.cursor_position = len(command) + 1


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Tool/Agent enhancement (improvements to LLM tools or agents)

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] All existing tests pass (`uv run pytest`)
- [ ] New tests have been added to cover the changes
- [X] Tests have been run locally
- [ ] Golden/character tests established for new features

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: 100%
- Coverage after changes: N/A (UI widget, manual testing)

## Pre-commit Checks
- [X] All pre-commit hooks pass
- [X] Code formatted with `ruff format`
- [X] Code passes `ruff check` without warnings
- [X] No Python file exceeds **600 lines**
- Note: All Changes pass pre-commit hook checks, certain hooks (check-file-length) fail for existing, unchanged files
## Checklist
- [ ] My code follows the Python coding standards (type hints, f-strings, pathlib, etc.)
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated documentation in `@documentation/` and `.claude/` directories
- [X] My changes generate no new warnings
- [ ] Dependencies are properly managed in `pyproject.toml`
- [ ] Any dependent changes have been merged and published
- [X] Created rollback point with clear commit message before changes

## Documentation Updates
<!-- Mark which documentation has been updated -->
- [ ] Updated relevant files in `@documentation/`
- [ ] Updated developer notes in `.claude/`
- [ ] README.md updated (if needed)

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->
This PR adds slash command autocompletion to the TUI. Typing / at the start of input displays a dropdown of all 8 commands with descriptions. The list filters as you type (e.g., /mo → /model) and completes with Tab/Enter. Subcommand completion (e.g., /resume load) is not included in this PR. The implementation uses a separate widget from file autocompletion for simpler maintenance. Commands are pre-computed at module load since they're statically defined.

**Autocompletion List** 
<img width="1572" height="1290" alt="image" src="https://github.com/user-attachments/assets/9727467a-b2d8-4ffc-9522-7de2b6562cd5" />

**Filtered List**
<img width="906" height="178" alt="image" src="https://github.com/user-attachments/assets/b28d6009-e801-4498-9324-9ea32d36c29c" />

**File and Slash autocomplete interactions**
Slash first, then File
<img width="1558" height="236" alt="image" src="https://github.com/user-attachments/assets/84674d2a-0f04-472c-be7e-c35679033ef9" />

File first, then Slash
<img width="1410" height="212" alt="image" src="https://github.com/user-attachments/assets/c831ad46-103f-44e0-adb3-6843336649a2" />


> PRs will fail CI if formatting/linting or file length rules are violated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a slash-command autocomplete in the editor that shows matching commands with descriptions as you type, appears only while composing a command (before a space), and inserts the selected command with a trailing space.
  * Integrated the new command autocomplete alongside existing file autocomplete in the editor UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->