### PR TITLE
Remove unused config fingerprint helper

### DIFF
--- a/src/tunacode/utils/config/__init__.py
+++ b/src/tunacode/utils/config/__init__.py
@@ -1,14 +1,12 @@
 """Configuration utilities: user config persistence."""
 
 from tunacode.utils.config.user_configuration import (
-    compute_config_fingerprint,
     load_config,
     save_config,
     set_default_model,
 )
 
 __all__ = [
-    "compute_config_fingerprint",
     "load_config",
     "save_config",
     "set_default_model",

--- a/src/tunacode/utils/config/user_configuration.py
+++ b/src/tunacode/utils/config/user_configuration.py
@@ -22,12 +22,6 @@ _config_fingerprint = None
 _config_cache = None
 
 
-def compute_config_fingerprint(config_obj) -> str:
-    """Returns a short hash/fingerprint for a config object/searchable for fastpath usage."""
-    b = json.dumps(config_obj, sort_keys=True).encode()
-    return hashlib.sha1(b).hexdigest()[:12]
-
-
 def load_config() -> UserConfig | None:
     """Load user config from file, using fingerprint fast path if available."""
     global _config_fingerprint, _config_cache


### PR DESCRIPTION
## Summary
- remove the unused `compute_config_fingerprint` helper and its export from the config utilities
- keep the configuration module interface focused on actively used functions

## Testing
- ruff check
- pytest *(fails: environment lacks async test plugin support)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b13e8fc708325bfac03e698fe2e2c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal configuration fingerprinting by consolidating helper function logic.

* **Chores**
  * Removed an internal utility export from the public API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->