### PR TITLE
feat: Add multi-line paste support with collapsed display

### DIFF
--- a/src/tunacode/ui/widgets/messages.py
+++ b/src/tunacode/ui/widgets/messages.py
@@ -19,10 +19,11 @@ class EditorCompletionsAvailable(Message):
 class EditorSubmitRequested(Message):
     """Submit event for the current editor content."""
 
-    def __init__(self, *, text: str, raw_text: str) -> None:
+    def __init__(self, *, text: str, raw_text: str, was_pasted: bool = False) -> None:
         super().__init__()
         self.text = text
         self.raw_text = raw_text
+        self.was_pasted = was_pasted
 
 
 class ToolResultDisplay(Message):


### PR DESCRIPTION
## Summary
- Captures full multi-line paste content before Input widget truncates to first line
- Shows `[[PASTED N LINES]]` indicator in input box for immediate feedback
- Displays collapsed view in RichLog: first 3 lines + `[[ N more lines ]]` + last 2 lines
- Updates StatusBar with paste line count

## Changes
| File | Change |
|------|--------|
| `src/tunacode/ui/widgets/editor.py` | Override `_on_paste()`, store full content, show indicator |
| `src/tunacode/ui/widgets/messages.py` | Add `was_pasted` flag to `EditorSubmitRequested` |
| `src/tunacode/ui/app.py` | Add `_format_collapsed_message()` for long paste display |

## Test plan
- [ ] Paste 5 lines → shows all 5 lines in RichLog
- [ ] Paste 15+ lines → shows collapsed view with `[[ N more lines ]]`
- [ ] Input box shows `[[PASTED N LINES]]` immediately on paste
- [ ] Typed content (not pasted) displays normally without collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pasted content exceeding 10 lines is now automatically collapsed, displaying the first and last lines with a count of hidden lines for improved readability.
  * Paste detection now provides visual feedback indicators in the editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->