### PR TITLE
Remove unused typing scaffolding from state transition

### DIFF
--- a/src/tunacode/core/agents/agent_components/state_transition.py
+++ b/src/tunacode/core/agents/agent_components/state_transition.py
@@ -3,12 +3,8 @@
 import threading
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from tunacode.types import AgentState
-
-if TYPE_CHECKING:
-    pass
 
 
 class InvalidStateTransitionError(Exception):


### PR DESCRIPTION
## Summary
- remove the unused TYPE_CHECKING guard from the state transition component to eliminate dead code

## Testing
- uv run ruff . *(fails: dependency download blocked in environment)*
- uv run pytest *(fails: dependency download blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ee710895c8325b64dd4e7ef72092a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization to improve maintainability without affecting functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->