### PR TITLE
chore: remove empty TYPE_CHECKING block in state_transition.py

### DIFF
--- a/memory-bank/cleanup-sweep/dead-code.md
+++ b/memory-bank/cleanup-sweep/dead-code.md
@@ -1,0 +1,120 @@
+# Dead Code Analysis Report
+**Generated:** 2025-12-14
+**Scope:** `/home/tuna/tunacode/src/tunacode`
+**Analysis Type:** Comprehensive dead code detection
+
+---
+
+## Executive Summary
+
+This report identifies unused code in the tunacode codebase. The analysis focused on:
+1. Exported functions/classes with zero external imports
+2. Unreferenced utility functions
+3. Unused dependencies in pyproject.toml
+4. Empty or minimal __init__.py files
+
+**Key Finding:** The codebase is generally lean with most exports being actively used. A few isolated unused exports were identified.
+
+---
+
+## 1. Unused Exported Functions/Classes
+
+### 1.1 `check_query_satisfaction` - UNUSED
+**File:** `/home/tuna/tunacode/src/tunacode/core/agents/main.py:516-523`
+**Status:** Dead Code (Legacy Hook)
+
+**Definition:**
+```python
+async def check_query_satisfaction(
+    agent: Agent,
+    original_query: str,
+    response: str,
+    state_manager: StateManager,
+) -> bool:
+    """Legacy hook for compatibility; completion still signaled via DONE marker."""
+    return True
+```
+
+**Evidence:**
+- Exported in `__all__` at `/home/tuna/tunacode/src/tunacode/core/agents/main.py:38-42`
+- Re-exported in `/home/tuna/tunacode/src/tunacode/core/agents/__init__.py:18,36`
+- **Zero imports found** - No file imports or uses this function
+- Function body is a no-op (always returns `True`)
+- Comment indicates this is a "legacy hook for compatibility"
+
+**Recommendation:** Remove this function and its exports. It serves no purpose.
+
+---
+
+### 1.2 Configuration Key Description Functions - UNUSED
+**File:** `/home/tuna/tunacode/src/tunacode/configuration/key_descriptions.py`
+**Status:** Dead Code (Utility Functions Never Called)
+
+**Unused Functions:**
+
+#### `get_key_description()` - Line 212-214
+```python
+def get_key_description(key_path: str) -> KeyDescription | None:
+    """Get description for a configuration key by its path."""
+    return CONFIG_KEY_DESCRIPTIONS.get(key_path)
+```
+**Evidence:** Defined but never imported or called anywhere in codebase.
+
+#### `get_service_type_for_api_key()` - Line 217-226
+```python
+def get_service_type_for_api_key(key_name: str) -> str | None:
+    """Determine the service type for an API key."""
+    # ... implementation
+```
+**Evidence:** Defined but never imported or called anywhere in codebase.
+
+#### `get_categories()` - Line 229-234
+```python
+def get_categories() -> dict[str, list[KeyDescription]]:
+    """Get all configuration keys organized by category."""
+    # ... implementation
+```
+**Evidence:** Defined but never imported or called anywhere in codebase.
+
+#### `get_configuration_glossary()` - Line 237-268
+```python
+def get_configuration_glossary() -> str:
+    """Generate a glossary of configuration terms for the help section."""
+    # ... implementation
+```
+**Evidence:** Defined but never imported or called anywhere in codebase.
+
+**Recommendation:** Remove these functions as premature optimization or document them as future-facing APIs.
+
+---
+
+## 2. Dependencies Analysis
+
+### 2.1 Core Dependencies - ALL USED
+
+**Result:** No unused production dependencies found. All packages in pyproject.toml are actively used.
+
+---
+
+## 3. No Large Commented-Out Code Blocks Found
+
+**Search Pattern:** Consecutive lines starting with `#` (10+ lines)
+**Result:** No significant commented-out code blocks detected
+
+---
+
+## 4. Codebase Health Metrics
+
+**Overall Assessment:** HEALTHY
+
+- **Total Python files analyzed:** 117
+- **Files with dead code:** 2 (main.py, key_descriptions.py)
+- **Dead code percentage:** ~1.7%
+- **Unused dependencies:** 0
+- **Large commented blocks:** 0
+
+---
+
+**Report prepared by:** Claude Code Analyzer
+**Analysis date:** 2025-12-14
+**Codebase version:** commit 4033081

--- a/memory-bank/cleanup-sweep/duplication.md
+++ b/memory-bank/cleanup-sweep/duplication.md
@@ -1,0 +1,283 @@
+# Duplication and Pattern Analysis Report
+
+Generated: 2025-12-14
+
+## Critical Duplications Found
+
+### 1. Duplicate FileFilter Class
+
+**Location 1:** `/home/tuna/tunacode/src/tunacode/utils/ui/file_filter.py`
+- Lines: 31-136
+- Last modified: 2025-12-05 (refactor clean up AI slop)
+- Uses: pathspec library for gitignore-aware filtering
+- Purpose: File autocomplete in TUI
+
+**Location 2:** `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py`
+- Lines: 28-94
+- Last modified: 2025-12-06 (grep decomposition)
+- Uses: fnmatch for fast globbing
+- Purpose: Grep tool file filtering
+
+**Evidence:**
+Both classes named `FileFilter` with different implementations:
+- utils/ui version: Uses pathspec, has `is_ignored()`, `complete()` methods
+- grep_components version: Uses fnmatch, has `fast_glob()` static method
+
+**Suggested Action:**
+DELETE `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py` (94 lines)
+- The grep tool should use the more mature pathspec-based FileFilter from utils/ui
+- The grep_components version is a simpler reimplementation with overlapping EXCLUDE_DIRS
+
+---
+
+### 2. Duplicate Gitignore Pattern Handling
+
+**Location 1:** `/home/tuna/tunacode/src/tunacode/utils/system/gitignore.py`
+- Lines: 1-156
+- Last modified: 2025-12-08
+- Has: `_load_gitignore_patterns()`, `_is_ignored()`, `list_cwd()`, DEFAULT_IGNORE_PATTERNS
+
+**Location 2:** `/home/tuna/tunacode/src/tunacode/utils/ui/file_filter.py`
+- Lines: 10-28, 38-43
+- Has: DEFAULT_IGNORES list, gitignore reading in `_build_spec()`
+
+**Evidence:**
+Three overlapping ignore pattern lists:
+```python
+# utils/system/gitignore.py
+DEFAULT_IGNORE_PATTERNS = {"node_modules/", "env/", "venv/", ".git/", "build/", "dist/", "__pycache__/", ...}
+
+# utils/ui/file_filter.py
+DEFAULT_IGNORES = [".git/", ".venv/", "venv/", "env/", "node_modules/", "__pycache__/", ...]
+
+# tools/grep_components/file_filter.py
+EXCLUDE_DIRS = {"node_modules", ".git", "__pycache__", ".venv", "venv", "dist", "build", ...}
+```
+
+**Suggested Action:**
+DELETE the ignore pattern lists in `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py` (lines 13-25)
+DELETE the ignore pattern list in `/home/tuna/tunacode/src/tunacode/utils/ui/file_filter.py` (lines 10-28)
+- Keep only the canonical DEFAULT_IGNORE_PATTERNS in utils/system/gitignore.py
+
+---
+
+### 3. Duplicate _truncate_line() Functions
+
+**Multiple identical implementations across 5 files:**
+
+**Location 1:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/web_fetch.py`
+- Lines: 69-73
+```python
+def _truncate_line(line: str) -> str:
+    """Truncate a single line if too wide."""
+    if len(line) > MAX_PANEL_LINE_WIDTH:
+        return line[: MAX_PANEL_LINE_WIDTH - 3] + "..."
+    return line
+```
+
+**Location 2:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/read_file.py`
+- Lines: 121-125
+- Identical to Location 1
+
+**Location 3:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/grep.py`
+- Lines: 114-118
+- Identical to Location 1
+
+**Location 4:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/bash.py`
+- Lines: 91-95
+- Identical to Location 1
+
+**Location 5:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/list_dir.py`
+- Lines: 88-92
+- Nearly identical but uses `MAX_PANEL_LINE_WIDTH` without subtracting 3:
+```python
+def _truncate_line(line: str) -> str:
+    """Truncate a single line if too wide."""
+    if len(line) > MAX_PANEL_LINE_WIDTH:
+        return line[:MAX_PANEL_LINE_WIDTH] + "..."  # BUG: should be MAX_PANEL_LINE_WIDTH - 3
+    return line
+```
+
+**Suggested Action:**
+DELETE `_truncate_line()` from these 5 files:
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/web_fetch.py` (lines 69-73)
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/read_file.py` (lines 121-125)
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/grep.py` (lines 114-118)
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/bash.py` (lines 91-95)
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/list_dir.py` (lines 88-92)
+
+Note: `/home/tuna/tunacode/src/tunacode/utils/ui/helpers.py` already has a `truncate()` function at line 19 that could replace these.
+
+---
+
+### 4. Duplicate Truncation Logic for Content
+
+**Multiple similar implementations:**
+
+**Location 1:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/web_fetch.py`
+- Lines: 76-84
+- Function: `_truncate_content(content: str) -> tuple[str, int, int]`
+
+**Location 2:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/bash.py`
+- Lines: 98-106
+- Function: `_truncate_output(output: str) -> tuple[str, int, int]`
+
+**Location 3:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/list_dir.py`
+- Lines: 95-101
+- Function: `_truncate_tree(content: str) -> tuple[str, int, int]`
+
+**Location 4:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/update_file.py`
+- Lines: 91+ (needs verification)
+- Function: `_truncate_diff(diff: str) -> tuple[str, int, int]`
+
+**Evidence:**
+All follow same pattern:
+1. Split content into lines
+2. Check if total lines exceed MAX_PANEL_LINES
+3. Return tuple of (truncated_content, shown_lines, total_lines)
+4. Call _truncate_line() on each line
+
+**Suggested Action:**
+DELETE these 4 truncation functions:
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/web_fetch.py` `_truncate_content()` (lines 76-84)
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/bash.py` `_truncate_output()` (lines 98-106)
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/list_dir.py` `_truncate_tree()` (lines 95-101)
+- `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/update_file.py` `_truncate_diff()` (lines 91+)
+
+---
+
+### 5. Duplicate MAX_RESULTS / MAX_GLOB Constants
+
+**Location 1:** `/home/tuna/tunacode/src/tunacode/tools/glob.py`
+- Line: 13
+- `MAX_RESULTS = 5000`
+
+**Location 2:** `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py`
+- Line: 11
+- `MAX_GLOB = 5_000  # Hard cap - protects memory & tokens`
+
+**Evidence:**
+Same value (5000), same purpose (limit file results), different names.
+
+**Suggested Action:**
+DELETE `MAX_GLOB = 5_000` from `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py` (line 11)
+- Both should use a constant from constants.py or reference glob.py's MAX_RESULTS
+
+---
+
+### 6. Duplicate EXCLUDE_DIRS Sets
+
+**Location 1:** `/home/tuna/tunacode/src/tunacode/tools/glob.py`
+- Lines: 14-30
+```python
+EXCLUDE_DIRS = {
+    "node_modules", ".git", "__pycache__", ".venv", "venv",
+    "dist", "build", ".pytest_cache", ".mypy_cache", ".tox",
+    "target", ".next", ".nuxt", "coverage", ".coverage",
+}
+```
+
+**Location 2:** `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py`
+- Lines: 13-25
+```python
+EXCLUDE_DIRS = {
+    "node_modules", ".git", "__pycache__", ".venv", "venv",
+    "dist", "build", ".pytest_cache", ".mypy_cache", ".tox", "target",
+}
+```
+
+**Evidence:**
+Nearly identical sets with glob.py having a few more entries (.next, .nuxt, coverage, .coverage).
+
+**Suggested Action:**
+DELETE `EXCLUDE_DIRS` from `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py` (lines 13-25)
+- Import from glob.py or constants.py instead
+
+---
+
+### 7. Duplicate GLOB_BATCH Constant (Unused)
+
+**Location:** `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py`
+- Line: 12
+- `GLOB_BATCH = 500  # Streaming batch size`
+
+**Evidence:**
+Searched entire file - this constant is defined but never used in the code.
+
+**Suggested Action:**
+DELETE `GLOB_BATCH = 500` from `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py` (line 12)
+- Dead code, no references found
+
+---
+
+### 8. Duplicate _truncate_path() Function
+
+**Location:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/glob.py`
+- Lines: 105+
+- Function: `_truncate_path(path: str) -> str`
+
+**Evidence:**
+This is functionally similar to the `_truncate_line()` duplicates but specialized for paths.
+
+**Suggested Action:**
+DELETE `_truncate_path()` from `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/glob.py`
+- Should use the common truncate utility instead
+
+---
+
+### 9. Duplicate Tool Output Formatting
+
+**Location 1:** `/home/tuna/tunacode/src/tunacode/tools/bash.py`
+- Function: `_format_output(command, exit_code, stdout, stderr, cwd)` (line found in grep)
+
+**Location 2:** `/home/tuna/tunacode/src/tunacode/tools/glob.py`
+- Function: `_format_output(pattern, matches, max_results, source)` (line found in grep)
+
+**Evidence:**
+Different signatures but both named `_format_output` and create formatted string output for tools.
+
+**Note:** These may not be true duplicates due to different purposes, but the naming collision suggests refactoring opportunity. Monitor for deletion if they share common formatting logic.
+
+---
+
+## Summary Statistics
+
+### Duplications by Category
+
+1. File Filtering Logic: 3 implementations (FileFilter class + gitignore pattern lists)
+2. Line Truncation: 5 identical `_truncate_line()` functions
+3. Content Truncation: 4 similar truncation functions
+4. Constants: 3 duplicated constants (MAX_RESULTS/MAX_GLOB, EXCLUDE_DIRS, GLOB_BATCH)
+5. Format Functions: 2 `_format_output()` functions (naming collision)
+
+### Total Lines to Delete
+
+Estimated: 250-300 lines of duplicate code
+
+### Files with Most Duplications
+
+1. `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py` - Entire file (94 lines) is duplicate
+2. `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/` - Multiple truncation duplicates across 5 files
+3. `/home/tuna/tunacode/src/tunacode/utils/ui/file_filter.py` - Overlapping ignore patterns
+
+---
+
+## Deprecated Patterns
+
+No deprecated callback patterns or old async patterns found. The codebase uses modern async/await consistently.
+
+---
+
+## Recommendations
+
+Priority 1 (Delete immediately):
+1. Delete `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py` entirely
+2. Delete all 5 `_truncate_line()` functions
+3. Delete unused GLOB_BATCH constant
+
+Priority 2 (Consolidate):
+1. Consolidate ignore pattern lists into single source
+2. Consolidate content truncation functions
+
+Priority 3 (Monitor):
+1. Review `_format_output()` naming collision

--- a/memory-bank/cleanup-sweep/imports.md
+++ b/memory-bank/cleanup-sweep/imports.md
@@ -1,0 +1,125 @@
+# Import Optimization Analysis - Tunacode Codebase
+
+**Analysis Date**: 2025-12-14
+**Target Directory**: `/home/tuna/tunacode/src/tunacode`
+**Scope**: Python imports in the tunacode codebase
+
+---
+
+## Executive Summary
+
+After a comprehensive analysis of 113+ Python files in the tunacode codebase, I found the import hygiene is **generally excellent**. The codebase demonstrates strong adherence to Python best practices:
+
+- **No wildcard imports** (`from X import *`) - All imports are explicit
+- **Proper TYPE_CHECKING usage** - Type-only imports are correctly guarded
+- **No duplicate imports** detected
+- **Clean __all__ exports** - Well-maintained public APIs
+
+However, I identified **3 issues** requiring attention.
+
+---
+
+## Findings
+
+### 1. Empty TYPE_CHECKING Block
+
+#### File: `/home/tuna/tunacode/src/tunacode/core/agents/agent_components/state_transition.py`
+
+**Lines**: 6, 10-11
+
+**Issue**:
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+```
+
+**Why Problematic**:
+- The TYPE_CHECKING import is unused since the guarded block is empty
+- Creates unnecessary noise in the import section
+
+**Suggested Action**:
+DELETE lines 6 and 10-11:
+```python
+# Remove these lines:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+```
+
+**Impact**: Low - purely cosmetic cleanup, no functional change
+
+---
+
+### 2. Unused Tool Import
+
+#### File: `/home/tuna/tunacode/src/tunacode/core/agents/main.py`
+
+**Lines**: 18-19
+
+**Current Code**:
+```python
+if TYPE_CHECKING:
+    from pydantic_ai import Tool  # noqa: F401
+```
+
+**Issue**:
+- Uses `noqa: F401` to suppress "imported but unused" warning
+- The `Tool` import is not actually used anywhere in the file body
+- This is a vestigial import from refactoring
+
+**Suggested Action**:
+DELETE lines 18-19 entirely
+
+**Impact**: Low - removes dead code, improves readability
+
+---
+
+### 3. ModelRequest Self-Assignment
+
+#### File: `/home/tuna/tunacode/src/tunacode/types.py`
+
+**Line**: 22
+
+**Current Code**:
+```python
+ModelRequest = ModelRequest  # type: ignore[misc]
+```
+
+**Issue**:
+- Self-assignment import alias pattern
+- Uses `type: ignore` to suppress mypy warning
+- This pattern is confusing and makes static analysis harder
+
+**Suggested Action**:
+Either remove the re-assignment if not needed, or add to `__all__` if it's meant to be public API.
+
+**Impact**: Medium - improves type checking and code clarity
+
+---
+
+## Import Statistics
+
+- **Total Python files analyzed**: 113+
+- **Files with imports**: 113
+- **Files with TYPE_CHECKING**: 9
+- **Files with empty TYPE_CHECKING blocks**: 1
+- **Wildcard imports**: 0
+- **Duplicate imports**: 0
+- **Unused imports (detected)**: 1
+
+---
+
+## Conclusion
+
+The tunacode codebase demonstrates **excellent import hygiene** with only 3 minor issues found across 113+ files.
+
+**Overall Grade**: A- (Excellent)
+
+---
+
+**Analysis Completed**: 2025-12-14
+**Files Analyzed**: 113+
+**Issues Found**: 3 (all low-priority)

--- a/memory-bank/cleanup-sweep/tasks.md
+++ b/memory-bank/cleanup-sweep/tasks.md
@@ -1,0 +1,216 @@
+# Cleanup Tasks - Prioritized List
+
+**Generated:** 2025-12-14
+**Total Tasks:** 12
+**Estimated Impact:** ~300 lines to DELETE
+
+---
+
+## Task 1: Remove Empty TYPE_CHECKING Block
+**Type:** import
+**Files:** `/home/tuna/tunacode/src/tunacode/core/agents/agent_components/state_transition.py`
+**Actions:**
+  - DELETE lines 6 (`from typing import TYPE_CHECKING`)
+  - DELETE lines 10-11 (`if TYPE_CHECKING: pass`)
+**Estimated Time:** 1 minute
+**Risk:** low
+**Verification:** `uv run ruff check src/tunacode/core/agents/agent_components/state_transition.py`
+
+---
+
+## Task 2: Remove Unused Tool Import
+**Type:** import
+**Files:** `/home/tuna/tunacode/src/tunacode/core/agents/main.py`
+**Actions:**
+  - DELETE lines 18-19 (TYPE_CHECKING block with unused Tool import)
+**Estimated Time:** 1 minute
+**Risk:** low
+**Verification:** `uv run ruff check src/tunacode/core/agents/main.py`
+
+---
+
+## Task 3: Remove check_query_satisfaction Dead Code
+**Type:** dead-code
+**Files:**
+  - `/home/tuna/tunacode/src/tunacode/core/agents/main.py`
+  - `/home/tuna/tunacode/src/tunacode/core/agents/__init__.py`
+**Actions:**
+  - DELETE lines 516-523 from main.py (function definition)
+  - DELETE `"check_query_satisfaction"` from `__all__` in main.py (line 41)
+  - DELETE import in `__init__.py` line 18
+  - DELETE `"check_query_satisfaction"` from `__all__` in `__init__.py` (line 36)
+**Estimated Time:** 3 minutes
+**Risk:** low
+**Verification:** `uv run pytest && uv run ruff check src/tunacode/core/agents/`
+
+---
+
+## Task 4: Remove Unused GLOB_BATCH Constant
+**Type:** dead-code
+**Files:** `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py`
+**Actions:**
+  - DELETE line 12 (`GLOB_BATCH = 500  # Streaming batch size`)
+**Estimated Time:** 1 minute
+**Risk:** low
+**Verification:** `uv run ruff check src/tunacode/tools/grep_components/file_filter.py`
+
+---
+
+## Task 5: Remove Duplicate _truncate_line() from web_fetch.py
+**Type:** duplication
+**Files:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/web_fetch.py`
+**Actions:**
+  - DELETE lines 69-73 (`_truncate_line()` function)
+  - UPDATE callers to use `from tunacode.utils.ui.helpers import truncate`
+**Estimated Time:** 3 minutes
+**Risk:** medium
+**Verification:** `uv run pytest tests/ -k web_fetch`
+
+---
+
+## Task 6: Remove Duplicate _truncate_line() from read_file.py
+**Type:** duplication
+**Files:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/read_file.py`
+**Actions:**
+  - DELETE lines 121-125 (`_truncate_line()` function)
+  - UPDATE callers to use `from tunacode.utils.ui.helpers import truncate`
+**Estimated Time:** 3 minutes
+**Risk:** medium
+**Verification:** `uv run pytest tests/ -k read_file`
+
+---
+
+## Task 7: Remove Duplicate _truncate_line() from grep.py
+**Type:** duplication
+**Files:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/grep.py`
+**Actions:**
+  - DELETE lines 114-118 (`_truncate_line()` function)
+  - UPDATE callers to use `from tunacode.utils.ui.helpers import truncate`
+**Estimated Time:** 3 minutes
+**Risk:** medium
+**Verification:** `uv run pytest tests/ -k grep`
+
+---
+
+## Task 8: Remove Duplicate _truncate_line() from bash.py
+**Type:** duplication
+**Files:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/bash.py`
+**Actions:**
+  - DELETE lines 91-95 (`_truncate_line()` function)
+  - UPDATE callers to use `from tunacode.utils.ui.helpers import truncate`
+**Estimated Time:** 3 minutes
+**Risk:** medium
+**Verification:** `uv run pytest tests/ -k bash`
+
+---
+
+## Task 9: Remove Duplicate _truncate_line() from list_dir.py
+**Type:** duplication
+**Files:** `/home/tuna/tunacode/src/tunacode/ui/renderers/tools/list_dir.py`
+**Actions:**
+  - DELETE lines 88-92 (`_truncate_line()` function - note: has bug, doesn't subtract 3)
+  - UPDATE callers to use `from tunacode.utils.ui.helpers import truncate`
+**Estimated Time:** 3 minutes
+**Risk:** medium
+**Verification:** `uv run pytest tests/`
+
+---
+
+## Task 10: Remove Unused key_descriptions Functions
+**Type:** dead-code
+**Files:** `/home/tuna/tunacode/src/tunacode/configuration/key_descriptions.py`
+**Actions:**
+  - DELETE lines 212-214 (`get_key_description()`)
+  - DELETE lines 217-226 (`get_service_type_for_api_key()`)
+  - DELETE lines 229-234 (`get_categories()`)
+  - DELETE lines 237-268 (`get_configuration_glossary()`)
+**Estimated Time:** 5 minutes
+**Risk:** low
+**Verification:** `uv run ruff check src/tunacode/configuration/`
+
+---
+
+## Task 11: Remove ModelRequest Self-Assignment
+**Type:** import
+**Files:** `/home/tuna/tunacode/src/tunacode/types.py`
+**Actions:**
+  - DELETE line 22 (`ModelRequest = ModelRequest  # type: ignore[misc]`)
+  - ADD `"ModelRequest"` to `__all__` if it should be re-exported
+**Estimated Time:** 2 minutes
+**Risk:** medium
+**Verification:** `uv run pytest && uv run mypy src/tunacode/types.py`
+
+---
+
+## Task 12: Consolidate Duplicate Ignore Patterns (Complex)
+**Type:** duplication
+**Files:**
+  - `/home/tuna/tunacode/src/tunacode/tools/grep_components/file_filter.py`
+  - `/home/tuna/tunacode/src/tunacode/utils/ui/file_filter.py`
+  - `/home/tuna/tunacode/src/tunacode/utils/system/gitignore.py`
+  - `/home/tuna/tunacode/src/tunacode/tools/glob.py`
+**Actions:**
+  - Keep canonical DEFAULT_IGNORE_PATTERNS in utils/system/gitignore.py
+  - DELETE duplicate EXCLUDE_DIRS from grep_components/file_filter.py (lines 13-25)
+  - UPDATE glob.py to import from canonical location
+  - UPDATE utils/ui/file_filter.py to use canonical patterns
+**Estimated Time:** 5+ minutes
+**Risk:** medium
+**Verification:** `uv run pytest && uv run ruff check .`
+
+---
+
+## Summary by Priority
+
+### Priority 1: Safe Single-Line Deletions (Tasks 1, 2, 4)
+- 3 tasks
+- ~4 lines to delete
+- Risk: LOW
+- Can run in parallel branches
+
+### Priority 2: Dead Code Removal (Tasks 3, 10)
+- 2 tasks
+- ~70 lines to delete
+- Risk: LOW
+- Independent changes
+
+### Priority 3: Truncation Function Consolidation (Tasks 5-9)
+- 5 tasks
+- ~25 lines to delete (5 functions x 5 lines)
+- Risk: MEDIUM
+- Should batch these together
+
+### Priority 4: Type/Import Cleanup (Task 11)
+- 1 task
+- ~1 line to change
+- Risk: MEDIUM
+- Needs type checking verification
+
+### Priority 5: Pattern Consolidation (Task 12)
+- 1 task
+- ~50 lines affected
+- Risk: MEDIUM
+- Larger refactor, do last
+
+---
+
+## Quick Stats
+
+| Category | Count | Lines to DELETE |
+|----------|-------|-----------------|
+| Unused imports | 3 | ~8 |
+| Dead code | 3 | ~80 |
+| Duplications | 6 | ~80 |
+| **Total** | **12** | **~168** |
+
+---
+
+## Execution Order Recommendation
+
+1. **First PR:** Tasks 1, 2, 4 (safest, fastest)
+2. **Second PR:** Task 3 (dead code function)
+3. **Third PR:** Tasks 5-9 batched (truncation consolidation)
+4. **Fourth PR:** Task 10 (key_descriptions cleanup)
+5. **Fifth PR:** Tasks 11, 12 (type/pattern cleanup)
+
+All tasks are independent and can run in parallel branches.

--- a/src/tunacode/core/agents/agent_components/state_transition.py
+++ b/src/tunacode/core/agents/agent_components/state_transition.py
@@ -3,12 +3,8 @@
 import threading
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from tunacode.types import AgentState
-
-if TYPE_CHECKING:
-    pass
 
 
 class InvalidStateTransitionError(Exception):


### PR DESCRIPTION
## Summary
Automated cleanup PR from `/cleanup-sweep`

## Changes
- Deleted unused `TYPE_CHECKING` import from `src/tunacode/core/agents/agent_components/state_transition.py`
- Deleted empty `if TYPE_CHECKING: pass` block (lines 10-11)

## Confidence
This is a **high-confidence** change:
- The TYPE_CHECKING import was imported but never used
- The guarded block was empty (`pass`)
- Ruff check passes
- Zero functional change

## Verification
- [x] Ruff check passes
- [ ] Build passes
- [ ] Tests pass

---
*Remaining cleanup tasks: see `memory-bank/cleanup-sweep/tasks.md`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive code quality analysis reports documenting dead code, duplication patterns, and import optimization findings.
  * Added a prioritized cleanup and remediation plan with actionable tasks and verification steps.

* **Chores**
  * Removed unused imports and cleaned up related code blocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->