### PR TITLE
fix(cli): default tunacode to TUI

### DIFF
--- a/src/tunacode/ui/main.py
+++ b/src/tunacode/ui/main.py
@@ -139,9 +139,7 @@ def run_headless(
     auto_approve: bool = typer.Option(
         False, "--auto-approve", help="Skip tool authorization prompts"
     ),
-    output_json: bool = typer.Option(
-        False, "--output-json", help="Output trajectory as JSON"
-    ),
+    output_json: bool = typer.Option(False, "--output-json", help="Output trajectory as JSON"),
     timeout: int = typer.Option(
         DEFAULT_TIMEOUT_SECONDS, "--timeout", help="Execution timeout in seconds"
     ),
@@ -188,9 +186,7 @@ def run_headless(
 
             if output_json:
                 trajectory = {
-                    "messages": [
-                        _serialize_message(msg) for msg in state_manager.session.messages
-                    ],
+                    "messages": [_serialize_message(msg) for msg in state_manager.session.messages],
                     "tool_calls": state_manager.session.tool_calls,
                     "usage": state_manager.session.session_total_usage,
                     "success": True,

--- a/src/tunacode/ui/widgets/editor.py
+++ b/src/tunacode/ui/widgets/editor.py
@@ -29,6 +29,7 @@ class Editor(Input):
     def _status_bar(self) -> StatusBar | None:
         """Get status bar or None if not available."""
         from textual.css.query import NoMatches
+
         try:
             return self.app.query_one(StatusBar)
         except NoMatches:

--- a/tests/test_cli_default_command.py
+++ b/tests/test_cli_default_command.py
@@ -27,4 +27,3 @@ def test_cli_help_hides_main_alias() -> None:
     )
     assert result.returncode == 0
     assert "\n│ main" not in result.stdout
-


### PR DESCRIPTION
## Summary\n\nRestore expected UX after adding headless subcommand support: running `tunacode` (or `tunacode --setup`) now starts the TUI by default, while `tunacode run` remains headless.\n\n## Changes\n- Add a Typer callback (invoke_without_command=True) to run the Textual TUI when no subcommand is provided.\n- Keep `tunacode main` as a hidden legacy alias.\n- Add help-output tests (shows `run`, hides `main`).\n\n## Testing\n- UV_CACHE_DIR=./.uv-cache uv run ruff check --fix .\n- UV_CACHE_DIR=./.uv-cache uv run pytest\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now prints app version with --version and runs a textual interactive mode via a dedicated command path
  * App schedules and reports available updates when launching the interactive mode

* **Refactor**
  * CLI flow reorganized for clearer defaults and model selection; deprecated alias hidden from help while preserved for compatibility
  * Model/configuration options clarified and modernized

* **Tests**
  * Added CLI help tests to ensure help output and hidden alias behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->