### PR TITLE
chore: pin ruff to 0.14.9

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pre-commit
+          pip install ruff==0.14.9 pre-commit
       - name: Run Ruff (lint)
         run: ruff check --output-format=github .
       - name: Run Ruff (format check only)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
 
   # Ruff - Fast Python linter and formatter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.14.9
     hooks:
       - id: ruff
         args: ['--fix', '--show-fixes']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ tunacode = "tunacode.ui.main:app"
 dev = [
     "build",
     "twine",
-    "ruff",
+    "ruff==0.14.9",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",


### PR DESCRIPTION
## Why

CI installs `ruff` from PyPI without a version pin, so `ruff format --check` can drift and fail even if local formatting passed on an older Ruff.

## What
- Pin Ruff in dev deps: `ruff==0.14.9`
- Pin Ruff in CI: `pip install ruff==0.14.9 pre-commit`
- Pin Ruff in pre-commit hook: `ruff-pre-commit` `v0.14.9`

## Notes
- `uv.lock` is currently gitignored in this repo, so the shared pin is enforced via `pyproject.toml` + CI + pre-commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ruff code linting tool to version 0.14.9 and synchronized it across the entire development environment, including continuous integration workflows, pre-commit hook configurations, and project dependencies. This change standardizes code quality checks and ensures uniform linting behavior across all development processes, local environments, and CI/CD pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->