### PR TITLE
fix: correct TOOL_VIEWPORT_LINES and DEFAULT_IGNORE_PATTERNS_COUNT

### DIFF
--- a/src/tunacode/constants.py
+++ b/src/tunacode/constants.py
@@ -34,11 +34,10 @@ MAX_SEARCH_RESULTS_DISPLAY = 20  # Search results shown before "+N more"
 
 # Tool panel viewport sizing (standardized across all renderers)
 LINES_RESERVED_FOR_HEADER_FOOTER = 4  # Header, params, separators, status
-TOOL_VIEWPORT_LINES = 10  # Fixed viewport height for uniform panels
+TOOL_VIEWPORT_LINES = MAX_PANEL_LINES - LINES_RESERVED_FOR_HEADER_FOOTER  # 26
 MIN_VIEWPORT_LINES = TOOL_VIEWPORT_LINES  # Min equals max for consistency
 TOOL_PANEL_WIDTH = 100  # Fixed width for uniform panels
 URL_DISPLAY_MAX_LENGTH = 70
-DEFAULT_IGNORE_PATTERNS_COUNT = 38
 
 # File autocomplete settings
 AUTOCOMPLETE_MAX_DEPTH = 3  # Levels deep from current prefix (sliding window)

--- a/src/tunacode/tools/list_dir.py
+++ b/src/tunacode/tools/list_dir.py
@@ -37,6 +37,8 @@ IGNORE_PATTERNS = [
     ".eggs/",
 ]
 
+IGNORE_PATTERNS_COUNT = len(IGNORE_PATTERNS)
+
 LIMIT = 100
 
 

--- a/src/tunacode/ui/renderers/tools/list_dir.py
+++ b/src/tunacode/ui/renderers/tools/list_dir.py
@@ -13,13 +13,13 @@ from rich.style import Style
 from rich.text import Text
 
 from tunacode.constants import (
-    DEFAULT_IGNORE_PATTERNS_COUNT,
     MAX_PANEL_LINE_WIDTH,
     MIN_VIEWPORT_LINES,
     TOOL_PANEL_WIDTH,
     TOOL_VIEWPORT_LINES,
     UI_COLORS,
 )
+from tunacode.tools.list_dir import IGNORE_PATTERNS_COUNT
 
 BOX_HORIZONTAL = "─"
 SEPARATOR_WIDTH = 52
@@ -78,9 +78,9 @@ def parse_result(args: dict[str, Any] | None, result: str) -> ListDirData | None
     show_hidden = args.get("show_hidden", False)
     ignore_list = args.get("ignore", [])
     ignore_count = (
-        DEFAULT_IGNORE_PATTERNS_COUNT + len(ignore_list)
+        IGNORE_PATTERNS_COUNT + len(ignore_list)
         if ignore_list
-        else DEFAULT_IGNORE_PATTERNS_COUNT
+        else IGNORE_PATTERNS_COUNT
     )
 
     return ListDirData(


### PR DESCRIPTION
## Summary
- Fixes #195: `TOOL_VIEWPORT_LINES` is now calculated dynamically (30 - 4 = 26) instead of hardcoded to 10
- Fixes #196: `DEFAULT_IGNORE_PATTERNS_COUNT` removed from constants.py; count now derived from `len(IGNORE_PATTERNS)` in list_dir.py

## Changes
- `constants.py`: Changed `TOOL_VIEWPORT_LINES = 10` to `TOOL_VIEWPORT_LINES = MAX_PANEL_LINES - LINES_RESERVED_FOR_HEADER_FOOTER`
- `constants.py`: Removed `DEFAULT_IGNORE_PATTERNS_COUNT = 38`
- `tools/list_dir.py`: Added `IGNORE_PATTERNS_COUNT = len(IGNORE_PATTERNS)`
- `ui/renderers/tools/list_dir.py`: Updated import to use `IGNORE_PATTERNS_COUNT` from source of truth

## Test plan
- [x] `ruff check --fix .` passes
- [x] `uv run pytest` passes (146 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display viewport now shows 26 lines instead of 10, providing improved visibility of content.

* **Chores**
  * Refactored internal ignore patterns configuration for better code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->