### PR TITLE
chore: Remove 35 unused constants from constants.py

### DIFF
--- a/src/tunacode/constants.py
+++ b/src/tunacode/constants.py
@@ -63,14 +63,6 @@ class ToolName(str, Enum):
     WEB_FETCH = "web_fetch"
 
 
-TOOL_READ_FILE = ToolName.READ_FILE
-TOOL_WRITE_FILE = ToolName.WRITE_FILE
-TOOL_UPDATE_FILE = ToolName.UPDATE_FILE
-TOOL_BASH = ToolName.BASH
-TOOL_GREP = ToolName.GREP
-TOOL_LIST_DIR = ToolName.LIST_DIR
-TOOL_GLOB = ToolName.GLOB
-
 READ_ONLY_TOOLS = [
     ToolName.READ_FILE,
     ToolName.GREP,
@@ -80,21 +72,6 @@ READ_ONLY_TOOLS = [
     ToolName.RESEARCH_CODEBASE,
     ToolName.WEB_FETCH,
 ]
-WRITE_TOOLS = [ToolName.WRITE_FILE, ToolName.UPDATE_FILE]
-EXECUTE_TOOLS = [ToolName.BASH]
-
-CMD_HELP = "/help"
-CMD_CLEAR = "/clear"
-CMD_YOLO = "/yolo"
-CMD_MODEL = "/model"
-CMD_EXIT = "exit"
-CMD_QUIT = "quit"
-
-DESC_HELP = "Show this help message"
-DESC_CLEAR = "Clear the conversation history"
-DESC_YOLO = "Toggle confirmation prompts on/off"
-DESC_MODEL = "List available models"
-DESC_EXIT = "Exit the application"
 
 COMMAND_PREFIX = "/"
 
@@ -133,19 +110,7 @@ NEXTSTEP_COLORS = {
     "error": "#1a1a1a",
 }
 
-UI_PROMPT_PREFIX = '<style fg="#00d7ff"><b>> </b></style>'
 UI_THINKING_MESSAGE = "[bold #00d7ff]Thinking...[/bold #00d7ff]"
-UI_DARKGREY_OPEN = "<darkgrey>"
-UI_DARKGREY_CLOSE = "</darkgrey>"
-UI_BOLD_OPEN = "<bold>"
-UI_BOLD_CLOSE = "</bold>"
-UI_KEY_ENTER = "Enter"
-UI_KEY_ESC_ENTER = "Esc + Enter"
-
-PANEL_ERROR = "Error"
-PANEL_MESSAGE_HISTORY = "Message History"
-PANEL_MODELS = "Models"
-PANEL_AVAILABLE_COMMANDS = "Available Commands"
 
 ERROR_PROVIDER_EMPTY = "Provider number cannot be empty"
 ERROR_INVALID_PROVIDER = "Invalid provider number"


### PR DESCRIPTION
## Summary

Removes 35 unused constant definitions from `constants.py`:

- **Tool name aliases** (7): `TOOL_READ_FILE`, `TOOL_WRITE_FILE`, `TOOL_UPDATE_FILE`, `TOOL_BASH`, `TOOL_GREP`, `TOOL_LIST_DIR`, `TOOL_GLOB`
- **Tool category lists** (2): `WRITE_TOOLS`, `EXECUTE_TOOLS`
- **Command strings** (6): `CMD_HELP`, `CMD_CLEAR`, `CMD_YOLO`, `CMD_MODEL`, `CMD_EXIT`, `CMD_QUIT`
- **Description strings** (5): `DESC_HELP`, `DESC_CLEAR`, `DESC_YOLO`, `DESC_MODEL`, `DESC_EXIT`
- **UI markup constants** (7): `UI_PROMPT_PREFIX`, `UI_DARKGREY_OPEN`, `UI_DARKGREY_CLOSE`, `UI_BOLD_OPEN`, `UI_BOLD_CLOSE`, `UI_KEY_ENTER`, `UI_KEY_ESC_ENTER`
- **Panel title constants** (4): `PANEL_ERROR`, `PANEL_MESSAGE_HISTORY`, `PANEL_MODELS`, `PANEL_AVAILABLE_COMMANDS`

All removed constants were defined but never imported anywhere in the codebase (verified with grep).

**Files changed:** 1 file, -35 lines

## Test plan

- [x] All 146 tests pass
- [x] Ruff lint passes
- [x] Verified no imports of removed constants exist in codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated internal constants for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->