### PR TITLE
refactor: remove dead code from agent_config.py

### DIFF
--- a/docs/codebase-map/state/state.md
+++ b/docs/codebase-map/state/state.md
@@ -65,16 +65,14 @@ Several state classes manage agent behavior:
 
 **Location:** `/Users/tuna/Desktop/tunacode/src/tunacode/core/agents/agent_components/agent_config.py`
 
-Four module-level dictionaries serve as global in-memory caches:
+Three module-level dictionaries serve as global in-memory caches:
 
 ```python
-_PROMPT_CACHE: dict[str, tuple[str, float]] = {}
 _TUNACODE_CACHE: dict[str, tuple[str, float]] = {}
 _AGENT_CACHE: dict[ModelName, PydanticAgent] = {}
 _AGENT_CACHE_VERSION: dict[ModelName, int] = {}
 ```
 
-- **`_PROMPT_CACHE`:** Caches system prompts with modification time for freshness
 - **`_TUNACODE_CACHE`:** Caches `AGENTS.md` content with modification time
 - **`_AGENT_CACHE`:** Stores `PydanticAgent` instances across requests
 - **`_AGENT_CACHE_VERSION`:** Manages cache versioning for invalidation

--- a/src/tunacode/core/agents/agent_components/agent_config.py
+++ b/src/tunacode/core/agents/agent_components/agent_config.py
@@ -43,8 +43,7 @@ from tunacode.tools.write_file import write_file
 from tunacode.types import ModelName, PydanticAgent
 from tunacode.utils.config.user_configuration import load_config
 
-# Module-level caches for system prompts
-_PROMPT_CACHE: dict[str, tuple[str, float]] = {}
+# Module-level cache for AGENTS.md context
 _TUNACODE_CACHE: dict[str, tuple[str, float]] = {}
 
 # Module-level cache for agents to persist across requests
@@ -172,7 +171,6 @@ def _build_request_hooks(
 
 def clear_all_caches():
     """Clear all module-level caches. Useful for testing."""
-    _PROMPT_CACHE.clear()
     _TUNACODE_CACHE.clear()
     _AGENT_CACHE.clear()
     _AGENT_CACHE_VERSION.clear()
@@ -183,29 +181,6 @@ def get_agent_tool():
     from pydantic_ai import Tool
 
     return Agent, Tool
-
-
-def _read_prompt_from_path(prompt_path: Path) -> str:
-    """Return prompt content from disk, leveraging the cache when possible."""
-    cache_key = str(prompt_path)
-
-    try:
-        current_mtime = prompt_path.stat().st_mtime
-    except FileNotFoundError as error:
-        raise FileNotFoundError from error
-
-    if cache_key in _PROMPT_CACHE:
-        cached_content, cached_mtime = _PROMPT_CACHE[cache_key]
-        if current_mtime == cached_mtime:
-            return cached_content
-
-    try:
-        content = prompt_path.read_text(encoding="utf-8").strip()
-    except FileNotFoundError as error:
-        raise FileNotFoundError from error
-
-    _PROMPT_CACHE[cache_key] = (content, current_mtime)
-    return content
 
 
 def load_system_prompt(base_path: Path, model: str | None = None) -> str:


### PR DESCRIPTION
## Summary

- Remove unused `_PROMPT_CACHE` module-level variable
- Remove unused `_read_prompt_from_path()` function (21 lines)
- Update `clear_all_caches()` to remove dead cache clear
- Fix stale documentation in `docs/codebase-map/state/state.md`

## Context

The `_PROMPT_CACHE` and `_read_prompt_from_path()` became dead code after the refactor to section-based prompt loading via `SectionLoader` in `src/tunacode/core/prompting/loader.py`. Grep confirmed zero call sites.

Closes #227

## Files Changed

| File | Changes |
|------|---------|
| `src/tunacode/core/agents/agent_components/agent_config.py` | -27 lines (dead code removal) |
| `docs/codebase-map/state/state.md` | Fix stale reference to removed cache |

## Quality Control

- [x] `uv run pytest` - 261 tests passed
- [x] `uv run ruff check --fix .` - All checks passed
- [x] Grep verified zero call sites for removed code

## Rollback

```bash
git revert 8207cf8
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal system prompt caching architecture.

* **Documentation**
  * Updated state documentation to reflect caching changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->