### PR TITLE
change default behavior of /update to install

### DIFF
--- a/src/tunacode/ui/commands/__init__.py
+++ b/src/tunacode/ui/commands/__init__.py
@@ -416,8 +416,8 @@ class ResumeCommand(Command):
 
 class UpdateCommand(Command):
     name = "update"
-    description = "Check for or install updates"
-    usage = "/update [check|install]"
+    description = "Update tunacode to latest version"
+    usage = "/update [check]"
 
     async def execute(self, app: TextualReplApp, args: str) -> None:
         import asyncio
@@ -427,7 +427,7 @@ class UpdateCommand(Command):
         from tunacode.utils.system.paths import check_for_updates
 
         parts = args.split(maxsplit=1) if args else []
-        subcommand = parts[0].lower() if parts else "check"
+        subcommand = parts[0].lower() if parts else "install"
 
         if subcommand == "check":
             app.notify("Checking for updates...")
@@ -437,7 +437,7 @@ class UpdateCommand(Command):
                 app.rich_log.write(f"Current version: {APP_VERSION}")
                 app.rich_log.write(f"Latest version:  {latest_version}")
                 app.notify(f"Update available: {latest_version}")
-                app.rich_log.write("Run /update install to upgrade")
+                app.rich_log.write("Run /update to upgrade")
             else:
                 app.notify(f"Already on latest version ({APP_VERSION})")
 
@@ -486,7 +486,7 @@ class UpdateCommand(Command):
 
         else:
             app.notify(f"Unknown subcommand: {subcommand}", severity="warning")
-            app.notify("Usage: /update [check|install]")
+            app.notify("Usage: /update [check]")
 
 
 COMMANDS: dict[str, Command] = {

--- a/uv.lock
+++ b/uv.lock
@@ -3132,7 +3132,7 @@ wheels = [
 
 [[package]]
 name = "tunacode-cli"
-version = "0.1.35"
+version = "0.1.36"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Description
  Swap the default behavior of `/update` command so that running `/update` performs the full update flow (check + confirm + install), while `/update check` does a read-only version check.

  **Before:** `/update` only checked for updates, requiring `/update install` to actually upgrade
  **After:** `/update` performs the full update flow, `/update check` for read-only check

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Test improvement
  - [ ] Refactoring (code improvement without changing functionality)
  - [ ] Tool/Agent enhancement (improvements to LLM tools or agents)

  ## Testing
  - [x] All existing tests pass (`uv run pytest`)
  - [ ] New tests have been added to cover the changes
  - [x] Tests have been run locally
  - [ ] Golden/character tests established for new features

  ### Test Coverage
  N/A - string changes only, no new logic

  ## Pre-commit Checks
  - [x] All pre-commit hooks pass
  - [x] Code formatted with `ruff format`
  - [x] Code passes `ruff check` without warnings
  - [x] No Python file exceeds **600 lines**

  ## Checklist
  - [x] My code follows the Python coding standards (type hints, f-strings, pathlib, etc.)
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code where necessary, particularly in hard-to-understand areas
  - [ ] I have updated documentation in `@documentation/` and `.claude/` directories
  - [x] My changes generate no new warnings
  - [x] Dependencies are properly managed in `pyproject.toml`
  - [x] Any dependent changes have been merged and published
  - [x] Created rollback point with clear commit message before changes

  ## Documentation Updates
  - [ ] Updated relevant files in `@documentation/`
  - [ ] Updated developer notes in `.claude/`
  - [ ] README.md updated (if needed)

  ## Additional Notes
  Minimal change - 4 string edits in `src/tunacode/ui/commands/__init__.py`:
  1. Updated description and usage text
  2. Changed default subcommand from `"check"` to `"install"`
  3. Updated help messages to reflect new default

  Closes #242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified the update command interface. Users can now run `/update` directly to upgrade to the latest version without specifying subcommands. Updated all help text and user guidance messaging to reflect the streamlined, more intuitive update process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->