### PR TITLE
fix: add submit tool to READ_ONLY_TOOLS

### DIFF
--- a/src/tunacode/constants.py
+++ b/src/tunacode/constants.py
@@ -86,6 +86,7 @@ READ_ONLY_TOOLS = [
     ToolName.RESEARCH_CODEBASE,
     ToolName.WEB_FETCH,
     ToolName.PRESENT_PLAN,
+    ToolName.SUBMIT,
 ]
 
 WRITE_TOOLS = [


### PR DESCRIPTION
## Summary

- Added `ToolName.SUBMIT` to `READ_ONLY_TOOLS` in `src/tunacode/constants.py`
- Submit tool was incorrectly triggering authorization prompts despite being side-effect-free

## Root Cause

The authorization system checks `READ_ONLY_TOOLS` to determine which tools can auto-execute. The submit tool only returns a string and has no side effects (no file writes, no shell commands), so it should be classified as read-only like `present_plan`.

## Changes

- `src/tunacode/constants.py:89` - Added `ToolName.SUBMIT` to `READ_ONLY_TOOLS`

## Test plan

- [x] Pre-commit hooks pass (ruff, mypy, bandit)
- [ ] Manual verification: submit tool no longer prompts for authorization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new SUBMIT tool to the available operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->