### PR TITLE
Fix message persistence on abort

### DIFF
--- a/.claude/metadata/issues.log
+++ b/.claude/metadata/issues.log
@@ -1,1 +1,2 @@
 [2026-01-19] [smell] Removed dead utils/security module and unused merge_json_objects().
+[2026-01-19] [bug] Abort/cancel paths dropped run messages and message serialization suppressed failures.

--- a/docs/codebase-map/modules/core-agents.md
+++ b/docs/codebase-map/modules/core-agents.md
@@ -196,9 +196,10 @@ Messages use pydantic-ai's standard types from `types/pydantic_ai.py`:
 - System prompt content (shorter in local mode)
 - Tool schemas (fewer in local mode)
 
-Message history persistence happens after a run finishes. `RequestOrchestrator`
-syncs `SessionState.messages` from `agent_run.all_messages()` to capture tool
-returns and other run output in the authoritative order.
+Message history persistence happens after a run finishes or aborts.
+`RequestOrchestrator` syncs `SessionState.messages` from
+`agent_run.all_messages()` on normal completion and on abort/cancel so partial
+conversations are not lost, while preserving authoritative tool ordering.
 
 ## Integration Points
 

--- a/docs/codebase-map/modules/core-state.md
+++ b/docs/codebase-map/modules/core-state.md
@@ -35,6 +35,12 @@ Singleton class with global instance access:
 - **save_session()** - Persist session to disk
 - **load_session()** - Restore session from disk
 
+## Persistence Contract
+
+- Messages must be dicts or pydantic-ai `ModelMessage` instances; serialization
+  raises on unsupported types to prevent silent data loss.
+- `save_session()` stamps `last_modified` and writes JSON to the session store.
+
 ## State Transitions
 
 ```


### PR DESCRIPTION
## Summary
- persist run messages on abort/cancel paths
- fail loudly when message serialization cannot be performed
- update core codebase-map docs and issues log

## Testing
- uv run ruff check --fix .
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message history now persists when operations are aborted or cancelled, preserving partial conversations.

* **Documentation**
  * Added Persistence Contract documentation detailing message type requirements and serialization behavior to prevent silent data loss.

* **Improvements**
  * Enhanced serialization validation to explicitly error on unsupported message types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->