### PR TITLE
fix: clean dangling tool calls for serialized sessions

### DIFF
--- a/.claude/qa/raw.md
+++ b/.claude/qa/raw.md
@@ -1,2 +1,3 @@
 [2026-01-15] [bug] message history missed tool-return when request ended early; fix by persisting agent_run.all_messages and keeping system notices out of history.
 [2026-01-16] [bug] tool panels rendered to the RichLog content region width; fix by setting explicit panel frame width from max_line_width plus TOOL_PANEL_HORIZONTAL_INSET.
+[2026-01-23] [bug] cancel cleanup skipped serialized dict messages because dangling tool calls were detected via tool_calls only; fix by scanning parts for tool-call entries.

--- a/docs/codebase-map/modules/core-agents.md
+++ b/docs/codebase-map/modules/core-agents.md
@@ -62,6 +62,7 @@ agent.iter() -> Provider HTTP Request
 **process_request()** in `main.py`
 - Creates RequestOrchestrator with agent configuration
 - **Prunes old tool outputs before iteration** (line 369)
+- Removes dangling tool calls before iteration, including serialized session messages
 - Iterates through agent responses until completion
 - Handles tool execution and result aggregation
 - Tracks iteration counters during the run

--- a/docs/codebase-map/modules/types.md
+++ b/docs/codebase-map/modules/types.md
@@ -50,6 +50,12 @@ Callback type definitions:
 - **ToolResult** - Tool result wrapper
 - Custom type adapters
 
+### messages.py
+**Serialized message shapes:**
+- **SerializedMessage** - JSON session message payload
+- **SerializedMessagePart** - JSON message part payload
+- **MessageLike** - Union for serialized dicts and runtime message objects
+
 ## Type Categories
 
 ### Primitive Aliases

--- a/src/tunacode/types/__init__.py
+++ b/src/tunacode/types/__init__.py
@@ -73,6 +73,12 @@ from tunacode.types.dataclasses import (
     ToolConfirmationRequest,
     ToolConfirmationResponse,
 )
+from tunacode.types.messages import (
+    MessageLike,
+    MessagePartLike,
+    SerializedMessage,
+    SerializedMessagePart,
+)
 
 # Pydantic-AI wrappers
 from tunacode.types.pydantic_ai import (
@@ -152,6 +158,11 @@ __all__ = [
     "NoticeCallback",
     "UICallback",
     "UIInputCallback",
+    # Serialized messages
+    "MessageLike",
+    "MessagePartLike",
+    "SerializedMessage",
+    "SerializedMessagePart",
     # State
     "SessionStateProtocol",
     "StateManagerProtocol",

--- a/src/tunacode/types/messages.py
+++ b/src/tunacode/types/messages.py
@@ -1,0 +1,64 @@
+"""Serialized message types for session persistence and cleanup."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, TypedDict
+
+
+class SerializedMessagePart(TypedDict, total=False):
+    """JSON-serialized message part structure."""
+
+    part_kind: str
+    tool_call_id: str
+    tool_name: str
+    args: str | dict[str, object] | None
+    content: str
+    timestamp: str
+    id: str | None
+    provider_details: dict[str, object] | None
+
+
+class SerializedMessage(TypedDict, total=False):
+    """JSON-serialized message structure."""
+
+    kind: str
+    parts: list[SerializedMessagePart]
+    tool_calls: list[SerializedMessagePart]
+    instructions: str | None
+    run_id: str | None
+    metadata: dict[str, object] | None
+    usage: dict[str, object]
+    model_name: str | None
+    timestamp: str | None
+    provider_name: str | None
+    provider_details: dict[str, object] | None
+    provider_response_id: str | None
+    finish_reason: str | None
+
+
+class MessagePartProtocol(Protocol):
+    """Protocol for message parts with tool call identifiers."""
+
+    part_kind: str | None
+    tool_call_id: str | None
+
+
+class MessagePartsProtocol(Protocol):
+    """Protocol for message objects with parts."""
+
+    parts: Sequence[MessagePartProtocol]
+
+
+MessagePartLike = SerializedMessagePart | MessagePartProtocol
+MessageLike = SerializedMessage | MessagePartsProtocol
+
+
+__all__ = [
+    "MessageLike",
+    "MessagePartLike",
+    "MessagePartProtocol",
+    "MessagePartsProtocol",
+    "SerializedMessage",
+    "SerializedMessagePart",
+]


### PR DESCRIPTION
## Summary
- clean dangling tool calls when session messages are serialized dicts by scanning parts
- define serialized message types for typed cleanup
- add regression test and docs for the cleanup path

## Testing
- uv run ruff check --fix .
- uv run pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where dangling tool calls in serialized session messages were not being properly detected and removed. The system now checks both direct tool-call metadata and individual message parts for tool-call entries.

* **Documentation**
  * Added clarifications about the message cleanup process and introduced documentation for new serialized message type definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->