### PR TITLE
fix: don't persist agent_run messages on abort to prevent dangling tool calls

### DIFF
--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -624,31 +624,29 @@ async def _finalize_buffered_tasks(
 
 
 def _message_has_tool_calls(message: Any) -> bool:
-    """Return True if message contains tool calls in parts or metadata."""
-    part_kind_tool_call = "tool-call"
-    part_kind_attr = "part_kind"
-    parts_attr = "parts"
-    tool_calls_attr = "tool_calls"
+    """Return True if message contains tool calls in parts or metadata.
 
+    Handles both pydantic-ai message objects and raw dicts (from failed deserialization).
+    """
+    # Handle both object and dict forms (dicts occur when deserialization fails)
     if isinstance(message, dict):
-        parts = message.get(parts_attr, [])
-        tool_calls = message.get(tool_calls_attr, [])
+        parts = message.get("parts", [])
+        tool_calls = message.get("tool_calls", [])
     else:
-        parts = getattr(message, parts_attr, [])
-        tool_calls = getattr(message, tool_calls_attr, [])
+        parts = getattr(message, "parts", [])
+        tool_calls = getattr(message, "tool_calls", [])
 
     if tool_calls:
         return True
-    if not parts:
-        return False
 
     for part in parts:
         if isinstance(part, dict):
-            part_kind = part.get(part_kind_attr)
+            part_kind = part.get("part_kind")
         else:
-            part_kind = getattr(part, part_kind_attr, None)
-        if part_kind == part_kind_tool_call:
+            part_kind = getattr(part, "part_kind", None)
+        if part_kind == "tool-call":
             return True
+
     return False
 
 


### PR DESCRIPTION
## Description

Fix session corruption when user aborts during tool execution. Previously, the exception handler called _persist_run_messages(agent_run) which copied incomplete state (tool calls without matching returns) from the aborted run to the session. This corrupted the session with dangling tool calls.

On subsequent requests, users encountered:
UserError: Cannot provide a new user prompt when the message history contains unprocessed tool calls.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] All existing tests pass (uv run pytest) - 377 tests passed
- [x] Tests have been run locally
- Manual verification: Created fresh session, triggered tool call, pressed ESC during execution, verified session file is clean with no dangling tool calls

## Pre-commit Checks

- [x] No Python file exceeds 600 lines

## Checklist

- [x] My code follows Python coding standards
- [x] I have performed a self-review
- [x] Commented code (added inline comment explaining why we dont persist agent_run messages)
- Updated documentation - Not needed, this is a bug fix
- [x] My changes generate no new warnings
- Dependencies unchanged
- No dependent changes
- [x] Created rollback point - commit 087279c4 before changes

## Root Cause

The exception handler in main.py had:
except (UserAbortError, asyncio.CancelledError):
    if agent_run is not None:
        self._persist_run_messages(agent_run, baseline_message_count)  # BUG: persists incomplete state
    # ... cleanup

When ESC happened mid-tool-execution, agent_run.all_messages() contained:
- Previous messages (state before abort)
- New user request  
- Model response with tool-call
- No tool-return (execution was aborted)

Copying this incomplete state corrupted the session.

## Fix

Remove _persist_run_messages() from the exception handler. Only clean up whatever is already in session.messages:
except (UserAbortError, asyncio.CancelledError):
    # DON'T persist agent_run messages - they contain the dangling tool call
    # Just clean up what's already in session.messages
    cleanup_applied = remove_dangling_tool_calls(...)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents aborted or canceled agent runs from leaving incomplete tool-call entries in session history.
  * Improves detection of tool calls across different message formats (top-level and within message parts), so dangling tool calls are more reliably identified and cleaned up during abort/finalize.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->