### PR TITLE
feat: show tokens/second in agent panel status bar

### DIFF
--- a/src/tunacode/ui/renderers/agent_response.py
+++ b/src/tunacode/ui/renderers/agent_response.py
@@ -192,7 +192,8 @@ def render_agent_response(
     status_parts = []
     if model:
         status_parts.append(_format_model(model))
-    status_parts.append(f"{tokens * 1000 / duration_ms:.0f} t/s")
+    if tokens > 0 and duration_ms > 0:
+        status_parts.append(f"{tokens * 1000 / duration_ms:.0f} t/s")
     if tokens > 0:
         status_parts.append(_format_tokens(tokens))
     if duration_ms > 0:


### PR DESCRIPTION
## Summary

- Adds t/s throughput metric to agent response panel status bar
- One line change: `status_parts.append(f"{tokens * 1000 / duration_ms:.0f} t/s")`

Display: `ANTH/claude-sonnet-4-5  ·  343 t/s  ·  1.2k  ·  3.5s`

## Test plan

- [ ] Run tunacode, send a prompt, verify t/s appears in status bar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent response status now shows a throughput metric (tokens per second) alongside model, token, and duration info when both token count and duration are available. This provides a quick view of response generation speed without changing other status formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->