### PR TITLE
chore: use pytest config in only one place

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,13 +215,6 @@ artifacts = [
     "src/tunacode/configuration/models_registry.json",
 ]
 
-[tool.pytest.ini_options]
-markers = [
-    "hypothesis: property-based tests using hypothesis (may be slow)",
-    "integration: tests requiring real API access (skipped by default)",
-]
-asyncio_mode = "auto"
-
 [dependency-groups]
 dev = [
     "pytest>=9.0.1",

--- a/pytest.ini
+++ b/pytest.ini
@@ -27,10 +27,9 @@ filterwarnings =
     ignore:You should use `LoggerProvider`:DeprecationWarning
     ignore:You should use `ProxyLoggerProvider`:DeprecationWarning
 
-
-
 # Custom markers
 markers =
     asyncio: marks tests as async (handled by pytest-asyncio)
     slow: marks tests as slow running
-    integration: marks tests that require external services
+    hypothesis: property-based tests using hypothesis (may be slow),
+    integration: tests requiring real API access (skipped by default),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Pytest ignores all settings with a warning:\
`configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)`\
I suggest moving all settings to `pytest.ini`.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test improvement
- [x] Refactoring (code improvement without changing functionality)
- [ ] Tool/Agent enhancement (improvements to LLM tools or agents)

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass (`uv run pytest`)
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally
- [ ] Golden/character tests established for new features

## Pre-commit Checks
- [x] All pre-commit hooks pass
- [x] Code formatted with `ruff format`
- [x] Code passes `ruff check` without warnings
- [x] No Python file exceeds **600 lines**

## Checklist
- [x] My code follows the Python coding standards (type hints, f-strings, pathlib, etc.)
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated documentation in `@documentation/` and `.claude/` directories
- [x] My changes generate no new warnings
- [x] Dependencies are properly managed in `pyproject.toml`
- [x] Any dependent changes have been merged and published
- [x] Created rollback point with clear commit message before changes

## Documentation Updates
<!-- Mark which documentation has been updated -->
- [ ] Updated relevant files in `@documentation/`
- [ ] Updated developer notes in `.claude/`
- [ ] README.md updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Consolidation of Pytest Configuration

**Overview:**
This PR consolidates pytest configuration settings into a single source of truth by moving all pytest options from `pyproject.toml` to `pytest.ini`.

**Changes:**

**pyproject.toml:**
- Removed the entire `[tool.pytest.ini_options]` section
- Specifically removed:
  - Custom pytest markers definitions (hypothesis, integration)
  - asyncio_mode configuration

**pytest.ini:**
- Added "hypothesis" marker with description: "property-based tests using hypothesis (may be slow)"
- Updated "integration" marker description from "marks tests that require external services" to "tests requiring real API access (skipped by default)"
- Maintained existing configuration for pythonpath, test discovery patterns, asyncio configuration, output options, and filter warnings

**Rationale:**
Pytest was emitting a warning when configuration existed in both locations: `configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)`. By consolidating all settings into pytest.ini, the configuration is now defined in a single location and the warning is eliminated.

**Impact:**
- No functional changes to test behavior
- Configuration is now centralized and easier to maintain
- Eliminates pytest configuration warnings
- All existing tests continue to pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->