### PR TITLE
test: remove unused CALLBACK_RESULT constant from tool retry tests

### DIFF
--- a/tests/integration/tools/test_tool_retry.py
+++ b/tests/integration/tools/test_tool_retry.py
@@ -27,7 +27,6 @@ MAX_PARALLEL_ENV = "TUNACODE_MAX_PARALLEL"
 SINGLE_PARALLEL_LIMIT = 1
 TOOL_NAME = "test_tool"
 NON_RETRYABLE_MESSAGE = "abort"
-CALLBACK_RESULT = "unused"
 
 
 class TestCalculateBackoff:


### PR DESCRIPTION
### Motivation
- Remove a dead/unused test constant to tighten tests and reduce clutter.

### Description
- Deleted the unused `CALLBACK_RESULT = "unused"` constant from `tests/integration/tools/test_tool_retry.py`.

### Testing
- Ran `uv run ruff check --fix .` which passed, and `uv run ruff check .` which passed; an attempted `uv run ruff .` failed due to `ruff` subcommand usage differences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7f3ad9ac83259f4a27f24d295f7c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dead Code Removal

Removed the unused `CALLBACK_RESULT = "unused"` constant from the test module `tests/integration/tools/test_tool_retry.py`. Verification confirms the constant is no longer referenced anywhere in the codebase.

**Scope of Changes:**
- Single line deleted from test module (1 line removed total)
- No changes to test logic, exception handling, or state management
- No changes to existing test implementations or assertions

**Testing:**
- Passed ruff linting (`rg check --fix .`)
- Passed ruff checking (`rg check .`)

**Risk Assessment:** Minimal — pure dead code elimination with no functional impact on test behavior or system state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->