### PR TITLE
feat: auto-copy highlighted text to clipboard on mouse release

### DIFF
--- a/src/tunacode/ui/clipboard.py
+++ b/src/tunacode/ui/clipboard.py
@@ -1,0 +1,65 @@
+"""Multi-backend clipboard module.
+
+Tries system clipboard tools first (xclip, wl-copy, xsel, pbcopy),
+then falls back to Textual's built-in OSC 52 escape sequence.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import Sequence
+
+# Backend command templates: (executable, args_to_write_stdin)
+_SYSTEM_BACKENDS: Sequence[tuple[str, list[str]]] = [
+    ("xclip", ["-selection", "clipboard"]),
+    ("wl-copy", []),
+    ("xsel", ["--clipboard", "--input"]),
+    ("pbcopy", []),
+]
+
+
+def _try_system_copy(text: str) -> bool:
+    """Attempt to copy via a system clipboard tool.
+
+    Iterates through known backends and uses the first available one.
+
+    Returns:
+        True if copy succeeded, False otherwise.
+    """
+    for executable, args in _SYSTEM_BACKENDS:
+        if shutil.which(executable) is None:
+            continue
+        try:
+            subprocess.run(
+                [executable, *args],
+                input=text.encode("utf-8"),
+                check=True,
+                timeout=2,
+            )
+            return True
+        except (subprocess.SubprocessError, OSError):
+            continue
+    return False
+
+
+def copy_to_clipboard(text: str, *, app: object | None = None) -> bool:
+    """Copy text to the system clipboard.
+
+    Tries system backends first, then Textual's OSC 52 via app.
+
+    Args:
+        text: The text to copy.
+        app: Optional Textual App instance for OSC 52 fallback.
+
+    Returns:
+        True if any backend succeeded, False if all failed.
+    """
+    if _try_system_copy(text):
+        return True
+
+    if app is not None and hasattr(app, "copy_to_clipboard"):
+        app.copy_to_clipboard(text)
+        return True
+
+    return False


### PR DESCRIPTION
Add CopyOnSelectStatic widget that overrides selection_updated() with
a debounce timer so that text highlighted via mouse drag is copied to
the system clipboard automatically when the mouse is released — zero
keystrokes required.

Multi-backend clipboard module tries xclip, wl-copy, xsel, pbcopy
before falling back to Textual's built-in OSC 52 escape sequence.

https://claude.ai/code/session_01MArPjAJWuFk89mqueZst1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## State Management
No changes to SessionState, messages, or tool calls. The PR introduces localized state management within CopyOnSelectStatic:
- `_copy_timer: Timer | None` instance variable tracks debounce timer lifecycle
- Proper state cleanup: timer is explicitly stopped and nullified when a new selection arrives (lines 41-43) and after copy completes (line 52)
- No state leaks; timer lifecycle is tied to widget lifecycle via `set_timer()`

## Exception Handling
**clipboard.py** implements robust error handling:
- Lines 34-39: `subprocess.run()` protected with explicit 2-second timeout and `check=True` flag
- Line 41: Catches both `subprocess.SubprocessError` and `OSError`, enabling graceful fallback to next backend
- Line 31: `shutil.which()` validates executable availability before invocation
- **Weakness**: Line 62 calls `app.copy_to_clipboard(text)` without exception handling; assumes success without verification

**chat.py** lacks defensive exception handling:
- Line 62: `copy_to_clipboard(text, app=self.app)` called without try/catch
- Line 63: `self.app.notify()` unprotected; potential UI failures propagate uncaught
- No recovery logic if clipboard or notification operations fail

## Type Safety
Demonstrates strong type discipline across both files:
- Uses `from __future__ import annotations` for forward compatibility
- Union types properly expressed: `Timer | None`, `Selection | None`, `object | None`
- Defensive `hasattr(app, "copy_to_clipboard")` check before method invocation (clipboard.py line 61)
- Proper sequence typing: `Sequence[tuple[str, list[str]]]` for backend configuration
- No type safety regressions

## Dead Code
No dead code identified. All introduced entities are utilized:
- `_COPY_DEBOUNCE_MS` constant used in line 47
- `_try_system_copy()` helper invoked in line 58 of public API
- `CopyOnSelectStatic` class instantiated in ChatContainer.write() (line 121)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->