### PR TITLE
Remove redundant original_query reset in session state

### DIFF
--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -350,7 +350,6 @@ class RequestOrchestrator:
         runtime.tool_registry.clear()
         runtime.batch_counter = 0
         runtime.consecutive_empty_responses = 0
-        session.task.original_query = ""
         session.usage.last_call_usage = UsageMetrics()
 
     def _set_original_query_once(self) -> None:


### PR DESCRIPTION
## Description
Remove the redundant line that resets `session.task.original_query` to an empty string in the `_reset_session_state()` method. This line is unnecessary as the original query should be set once via the `_set_original_query_once()` method and should not be cleared during session state resets.

## Type of Change
- [x] Refactoring (code improvement without changing functionality)

## Rationale
The `original_query` field is managed by the `_set_original_query_once()` method which ensures it's only set once per session. Clearing it during `_reset_session_state()` contradicts this design pattern and could cause issues if session state is reset multiple times during a session's lifetime.

## Testing
- [ ] All existing tests pass (`uv run pytest`)
- [ ] Tests have been run locally

## Pre-commit Checks
- [ ] All pre-commit hooks pass
- [ ] Code formatted with `ruff format`
- [ ] Code passes `ruff check` without warnings

## Checklist
- [x] My code follows the Python coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

https://claude.ai/code/session_01UkoQwgqQPs7ibB3UdL7Xp7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## State Management Changes

**Removed redundant `original_query` reset**: Eliminated the line `session.task.original_query = ""` from `_reset_session_state()`.

This fixes a critical state management bug where `original_query` was being cleared before `_set_original_query_once()` could check its value. The guard condition in `_set_original_query_once()` (`if task_state.original_query: return`) was always evaluating to false due to the preceding reset, causing `original_query` to be unconditionally overwritten with the current message on every request instead of being preserved across multi-turn interactions.

With this change:
- `original_query` now persists across multiple requests within a session, maintaining the initial user query for the session lifetime
- The "set once" pattern is now functional—the value is set on first request and preserved thereafter
- The `/clear` command remains the explicit, user-initiated mechanism for resetting `original_query` when full state reset is required

## Call Sequence Impact

The request initialization order (`_reset_session_state()` → `_set_original_query_once()`) now correctly implements the intended semantics: runtime state is cleared for each request while task-level context (`original_query`) persists across the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->