### PR TITLE
feat: implement minimax first-class alchemy routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "typer>=0.15.0",
     "click>=8.1.0,<8.2.0",
     "prompt_toolkit>=3.0.52,<4.0.0",
-    "tiny-agent-os",
+    "tiny-agent-os>=1.2.1",
     "pygments>=2.19.2,<3.0.0",
     "rich>=14.2.0,<15.0.0",
     "defusedxml",

--- a/src/tunacode/configuration/defaults.py
+++ b/src/tunacode/configuration/defaults.py
@@ -13,6 +13,8 @@ DEFAULT_USER_CONFIG: UserConfig = {
     "env": {
         "ANTHROPIC_API_KEY": "",
         "GEMINI_API_KEY": "",
+        "MINIMAX_API_KEY": "",
+        "MINIMAX_CN_API_KEY": "",
         "OPENAI_API_KEY": "",
         ENV_OPENAI_BASE_URL: "",
         "OPENROUTER_API_KEY": "",

--- a/src/tunacode/configuration/models.py
+++ b/src/tunacode/configuration/models.py
@@ -142,6 +142,24 @@ def get_provider_base_url(provider_id: str) -> str | None:
     return provider.get("api")
 
 
+def get_provider_alchemy_api(provider_id: str) -> str | None:
+    """Return the alchemy API routing identifier for a provider."""
+    registry = get_cached_models_registry()
+    if registry is None:
+        return None
+
+    provider = registry.get(provider_id, {})
+    alchemy_api = provider.get("alchemy_api")
+    if not isinstance(alchemy_api, str):
+        return None
+
+    normalized_alchemy_api = alchemy_api.strip()
+    if not normalized_alchemy_api:
+        return None
+
+    return normalized_alchemy_api
+
+
 def get_model_context_window(model_string: str) -> int:
     """Get context window limit for a model from cached models_registry data.
 

--- a/src/tunacode/configuration/models_registry.json
+++ b/src/tunacode/configuration/models_registry.json
@@ -12887,7 +12887,7 @@
   "minimax-cn-coding-plan": {
     "id": "minimax-cn-coding-plan",
     "env": [
-      "MINIMAX_API_KEY"
+      "MINIMAX_CN_API_KEY"
     ],
     "npm": "@ai-sdk/anthropic",
     "api": "https://api.minimaxi.com/anthropic/v1",
@@ -13010,7 +13010,8 @@
           "output": 131072
         }
       }
-    }
+    },
+    "alchemy_api": "minimax-completions"
   },
   "novita-ai": {
     "id": "novita-ai",
@@ -22861,7 +22862,7 @@
   "minimax-cn": {
     "id": "minimax-cn",
     "env": [
-      "MINIMAX_API_KEY"
+      "MINIMAX_CN_API_KEY"
     ],
     "npm": "@ai-sdk/anthropic",
     "api": "https://api.minimaxi.com/anthropic/v1",
@@ -22984,7 +22985,8 @@
           "output": 131072
         }
       }
-    }
+    },
+    "alchemy_api": "minimax-completions"
   },
   "bailing": {
     "id": "bailing",
@@ -30350,7 +30352,8 @@
           "output": 131072
         }
       }
-    }
+    },
+    "alchemy_api": "minimax-completions"
   },
   "kimi-for-coding": {
     "id": "kimi-for-coding",
@@ -65908,7 +65911,8 @@
           "output": 131072
         }
       }
-    }
+    },
+    "alchemy_api": "minimax-completions"
   },
   "vultr": {
     "id": "vultr",

--- a/src/tunacode/core/agents/agent_components/agent_config.py
+++ b/src/tunacode/core/agents/agent_components/agent_config.py
@@ -19,6 +19,7 @@ from tinyagent.alchemy_provider import OpenAICompatModel, stream_alchemy_openai_
 
 from tunacode.configuration.limits import get_max_tokens
 from tunacode.configuration.models import (
+    get_provider_alchemy_api,
     get_provider_base_url,
     get_provider_env_var,
     load_models_registry,
@@ -319,11 +320,18 @@ def _build_tinyagent_model(
     provider_id, model_id = parse_model_string(model)
     resolved_base_url = _resolve_base_url(session, provider_id)
     base_url = _require_provider_base_url(provider_id, resolved_base_url)
+    resolved_alchemy_api = get_provider_alchemy_api(provider_id)
+
+    model_kwargs: dict[str, str] = {}
+    if base_url:
+        model_kwargs["base_url"] = base_url
+    if resolved_alchemy_api:
+        model_kwargs["api"] = resolved_alchemy_api
 
     return OpenAICompatModel(
         provider=provider_id,
         id=model_id,
-        **({"base_url": base_url} if base_url else {}),
+        **model_kwargs,
     )
 
 

--- a/src/tunacode/core/compaction/controller.py
+++ b/src/tunacode/core/compaction/controller.py
@@ -12,6 +12,7 @@ from tinyagent.alchemy_provider import OpenAICompatModel, stream_alchemy_openai_
 
 from tunacode.configuration.limits import get_max_tokens
 from tunacode.configuration.models import (
+    get_provider_alchemy_api,
     get_provider_base_url,
     get_provider_env_var,
     load_models_registry,
@@ -366,10 +367,17 @@ class CompactionController:
         resolved_base_url = self._resolve_base_url(provider_id)
         base_url = self._require_provider_base_url(provider_id, resolved_base_url)
 
+        resolved_alchemy_api = get_provider_alchemy_api(provider_id)
+
+        model_kwargs: dict[str, str] = {}
+        if base_url:
+            model_kwargs["base_url"] = base_url
+        if resolved_alchemy_api:
+            model_kwargs["api"] = resolved_alchemy_api
         return OpenAICompatModel(
             provider=provider_id,
             id=model_id,
-            **({"base_url": base_url} if base_url else {}),
+            **model_kwargs,
         )
 
     def _resolve_base_url(self, provider_id: str) -> str | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,8 @@ def isolate_environment(monkeypatch: pytest.MonkeyPatch) -> None:
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
         "GEMINI_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
         "OPENROUTER_API_KEY",
         "TUNACODE_CONFIG",
     ]

--- a/tests/integration/core/test_minimax_execution_path.py
+++ b/tests/integration/core/test_minimax_execution_path.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tunacode.core.agents.agent_components import agent_config
+from tunacode.core.session import StateManager
+
+MINIMAX_CODING_PLAN_MODEL = "minimax-coding-plan:MiniMax-M2.1"
+MINIMAX_API_KEY_ENV = "MINIMAX_API_KEY"
+MINIMAX_API_KEY_VALUE = "sk-minimax"
+MINIMAX_CHAT_COMPLETIONS_URL = "https://api.minimax.io/anthropic/v1/chat/completions"
+MINIMAX_ALCHEMY_API = "minimax-completions"
+
+
+class _FakeResponse:
+    def __init__(self) -> None:
+        self._done_emitted = False
+
+    def __aiter__(self) -> _FakeResponse:
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        if self._done_emitted:
+            raise StopAsyncIteration
+
+        self._done_emitted = True
+        return {"type": "done"}
+
+    async def result(self) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "timestamp": None,
+        }
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_minimax_coding_plan_execution_path_uses_minimax_alchemy_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    state_manager = StateManager()
+    session = state_manager.session
+    session.current_model = MINIMAX_CODING_PLAN_MODEL
+    session.user_config["env"][MINIMAX_API_KEY_ENV] = MINIMAX_API_KEY_VALUE
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_stream(model: Any, context: Any, options: dict[str, Any]) -> _FakeResponse:
+        captured["model"] = model
+        captured["context"] = context
+        captured["options"] = options
+        return _FakeResponse()
+
+    monkeypatch.setattr(agent_config, "stream_alchemy_openai_completions", _fake_stream)
+    monkeypatch.setattr(agent_config, "load_system_prompt", lambda _base_path, model=None: "")
+    monkeypatch.setattr(agent_config, "load_tunacode_context", lambda: "")
+
+    agent = agent_config.get_or_create_agent(MINIMAX_CODING_PLAN_MODEL, state_manager)
+    response_text = await agent.prompt_text("Reply with ok")
+
+    assert response_text == "ok"
+
+    model = captured["model"]
+    assert model.provider == "minimax-coding-plan"
+    assert model.id == "MiniMax-M2.1"
+    assert model.api == MINIMAX_ALCHEMY_API
+    assert model.base_url == MINIMAX_CHAT_COMPLETIONS_URL
+
+    options = captured["options"]
+    assert options["api_key"] == MINIMAX_API_KEY_VALUE

--- a/tests/unit/configuration/test_default_config_minimax_keys.py
+++ b/tests/unit/configuration/test_default_config_minimax_keys.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from tunacode.configuration.defaults import DEFAULT_USER_CONFIG
+
+MINIMAX_API_KEY_ENV = "MINIMAX_API_KEY"
+MINIMAX_CN_API_KEY_ENV = "MINIMAX_CN_API_KEY"
+
+
+def test_default_user_config_exposes_minimax_api_key_slots() -> None:
+    env = DEFAULT_USER_CONFIG["env"]
+
+    assert MINIMAX_API_KEY_ENV in env
+    assert MINIMAX_CN_API_KEY_ENV in env
+    assert env[MINIMAX_API_KEY_ENV] == ""
+    assert env[MINIMAX_CN_API_KEY_ENV] == ""

--- a/tests/unit/configuration/test_models_registry_minimax_contract.py
+++ b/tests/unit/configuration/test_models_registry_minimax_contract.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from tunacode.configuration.models import (
+    get_provider_alchemy_api,
+    get_provider_env_var,
+    load_models_registry,
+)
+
+MINIMAX_ALCHEMY_API = "minimax-completions"
+MINIMAX_API_KEY_ENV = "MINIMAX_API_KEY"
+MINIMAX_CN_API_KEY_ENV = "MINIMAX_CN_API_KEY"
+
+
+def test_minimax_provider_env_contracts_are_normalized() -> None:
+    load_models_registry()
+
+    assert get_provider_env_var("minimax") == MINIMAX_API_KEY_ENV
+    assert get_provider_env_var("minimax-coding-plan") == MINIMAX_API_KEY_ENV
+    assert get_provider_env_var("minimax-cn") == MINIMAX_CN_API_KEY_ENV
+    assert get_provider_env_var("minimax-cn-coding-plan") == MINIMAX_CN_API_KEY_ENV
+
+
+def test_minimax_provider_alchemy_api_contracts_are_normalized() -> None:
+    load_models_registry()
+
+    assert get_provider_alchemy_api("minimax") == MINIMAX_ALCHEMY_API
+    assert get_provider_alchemy_api("minimax-coding-plan") == MINIMAX_ALCHEMY_API
+    assert get_provider_alchemy_api("minimax-cn") == MINIMAX_ALCHEMY_API
+    assert get_provider_alchemy_api("minimax-cn-coding-plan") == MINIMAX_ALCHEMY_API

--- a/uv.lock
+++ b/uv.lock
@@ -1936,14 +1936,14 @@ wheels = [
 
 [[package]]
 name = "tiny-agent-os"
-version = "1.1.5"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/41/e7b46c3d17b65cbb4a3affcad1220d742fa77da24a218952aaa04f3c55ad/tiny_agent_os-1.1.5.tar.gz", hash = "sha256:50845ca3a2064c14557ff34ad8e415341535a56d067eaf3cae1f008167eca891", size = 203489, upload-time = "2026-02-12T23:06:19.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/6e/36af597658d3c29e51dc7aedc05e37c3278db5aee7605e9ab582c9946885/tiny_agent_os-1.2.1.tar.gz", hash = "sha256:ff09fa25c4088714d7cc82af4176e4fc02045d8d175f54d1ae1b52268c409ed1", size = 178994, upload-time = "2026-02-18T21:15:20.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/81/cf49248cab3b51cdb6cc730918c7af16583db3a0d4c8e7d754be5eb838eb/tiny_agent_os-1.1.5-cp310-abi3-manylinux_2_38_x86_64.whl", hash = "sha256:cdae8d71417e6deb289820644f7ad362691bb7f998c0c5c1099e7c183d42d09f", size = 4227668, upload-time = "2026-02-12T23:06:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/69/0e843e95219fb49730959eca1183d280a1e61f383aeea401fe4cd3fa59f9/tiny_agent_os-1.2.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8b6c284311a71bff2b4f7bc3921c70aff0f7df4741f82b7624eff364a9c7822f", size = 4280410, upload-time = "2026-02-18T21:15:18.608Z" },
 ]
 
 [[package]]
@@ -2103,7 +2103,7 @@ requires-dist = [
     { name = "textual", specifier = ">=4.0.0,<5.0.0" },
     { name = "textual-autocomplete", specifier = ">=4.0.6" },
     { name = "textual-dev", marker = "extra == 'dev'" },
-    { name = "tiny-agent-os" },
+    { name = "tiny-agent-os", specifier = ">=1.2.1" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "typer", specifier = ">=0.15.0" },
     { name = "unimport", marker = "extra == 'dev'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- add first-class MiniMax provider routing through alchemy contracts
- update model registry defaults and provider key handling for minimax variants
- add integration and unit coverage for minimax execution path and config contracts

## Validation
- uv run pytest
- uv run ruff check .