### PR TITLE
Add lightweight query handoff routing before main agent

### DIFF
--- a/.claude/patterns/query-handoff-routing.md
+++ b/.claude/patterns/query-handoff-routing.md
@@ -1,0 +1,31 @@
+---
+title: Query handoff routing before main agent
+status: active
+date: 2026-02-25
+scope: core/agents
+---
+
+## Summary
+
+Add a small typed pre-routing step that transforms the raw user query into a compact handoff envelope for the main agent.
+
+## Why
+
+- Keeps routing logic isolated and fast.
+- Preserves the original user query for task state and UI.
+- Gives the main agent explicit intent hints (`debug`, `build`, `explain`, `general`, `command`).
+
+## Implementation notes
+
+- `QueryHandoff` is a frozen dataclass.
+- `build_query_handoff(query)` does keyword routing and returns:
+  - `original_query`
+  - `route`
+  - `handoff_instruction`
+  - `message_for_main_agent`
+- Slash commands (`/compact`, etc.) bypass wrapping and are passed through unchanged.
+
+## Validation
+
+- Unit tests assert route selection and command passthrough.
+- `RequestOrchestrator` stores both `user_message` and routed `message` and uses the original message for `task.original_query` and empty-response follow-up.

--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -52,6 +52,7 @@ from .helpers import (
     is_context_overflow_error,
     parse_canonical_usage,
 )
+from .query_handoff import build_query_handoff
 
 __all__ = ["process_request", "get_agent_tool"]
 DEFAULT_MAX_ITERATIONS: int = 15
@@ -139,7 +140,9 @@ class RequestOrchestrator:
         notice_callback: NoticeCallback | None = None,
         compaction_status_callback: CompactionStatusCallback | None = None,
     ) -> None:
-        self.message = message
+        self.user_message = message
+        self.handoff = build_query_handoff(message)
+        self.message = self.handoff.message_for_main_agent
         self.model = model
         self.state_manager = state_manager
         self.tool_callback = tool_callback
@@ -239,7 +242,7 @@ class RequestOrchestrator:
         task_state = self.state_manager.session.task
         if task_state.original_query:
             return
-        task_state.original_query = self.message
+        task_state.original_query = self.user_message
 
     def _configure_compaction_callbacks(self) -> None:
         self.compaction_controller.set_status_callback(self.compaction_status_callback)
@@ -664,7 +667,7 @@ class RequestOrchestrator:
         self.empty_handler.track(is_empty)
         if is_empty and self.empty_handler.should_intervene():
             await self.empty_handler.prompt_action(
-                self.message,
+                self.user_message,
                 "empty",
                 runtime.iteration_count or 1,
             )

--- a/src/tunacode/core/agents/query_handoff.py
+++ b/src/tunacode/core/agents/query_handoff.py
@@ -1,0 +1,106 @@
+"""Fast query-to-agent handoff routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+COMMAND_PREFIX: str = "/"
+ROUTING_HEADER: str = "[ROUTING HANDOFF]"
+USER_QUERY_LABEL: str = "User query:"
+
+DEBUG_KEYWORDS: tuple[str, ...] = (
+    "bug",
+    "debug",
+    "error",
+    "failing",
+    "failure",
+    "fix",
+    "traceback",
+)
+BUILD_KEYWORDS: tuple[str, ...] = (
+    "add",
+    "build",
+    "create",
+    "implement",
+    "refactor",
+    "write",
+)
+EXPLAIN_KEYWORDS: tuple[str, ...] = (
+    "explain",
+    "how",
+    "summarize",
+    "what",
+    "why",
+)
+
+DEBUG_HANDOFF: str = "Prioritize fast diagnosis, isolate root cause, then propose a minimal fix."
+BUILD_HANDOFF: str = "Prioritize a small typed implementation with minimal surface area changes."
+EXPLAIN_HANDOFF: str = (
+    "Prioritize clear explanation first, then provide concrete implementation guidance."
+)
+GENERAL_HANDOFF: str = (
+    "Prioritize the smallest correct next step and surface assumptions explicitly."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QueryHandoff:
+    """Routing decision passed to the main agent."""
+
+    original_query: str
+    route: str
+    handoff_instruction: str
+    message_for_main_agent: str
+
+
+def _contains_any_keyword(query_text: str, keywords: tuple[str, ...]) -> bool:
+    return any(keyword in query_text for keyword in keywords)
+
+
+def _route_query(query: str) -> tuple[str, str]:
+    normalized_query = query.strip()
+    if not normalized_query:
+        return "general", GENERAL_HANDOFF
+
+    if normalized_query.startswith(COMMAND_PREFIX):
+        return "command", "Pass through exactly without rewriting."
+
+    lowered_query = normalized_query.lower()
+
+    if _contains_any_keyword(lowered_query, DEBUG_KEYWORDS):
+        return "debug", DEBUG_HANDOFF
+
+    if _contains_any_keyword(lowered_query, BUILD_KEYWORDS):
+        return "build", BUILD_HANDOFF
+
+    if _contains_any_keyword(lowered_query, EXPLAIN_KEYWORDS):
+        return "explain", EXPLAIN_HANDOFF
+
+    return "general", GENERAL_HANDOFF
+
+
+def build_query_handoff(query: str) -> QueryHandoff:
+    """Create a compact routing handoff for the main agent."""
+    route, handoff_instruction = _route_query(query)
+    stripped_query = query.strip()
+    if route == "command":
+        return QueryHandoff(
+            original_query=query,
+            route=route,
+            handoff_instruction=handoff_instruction,
+            message_for_main_agent=stripped_query,
+        )
+
+    message_for_main_agent = (
+        f"{ROUTING_HEADER}\n"
+        f"Route: {route}\n"
+        f"Handoff: {handoff_instruction}\n"
+        f"{USER_QUERY_LABEL}\n"
+        f"{stripped_query}"
+    )
+    return QueryHandoff(
+        original_query=query,
+        route=route,
+        handoff_instruction=handoff_instruction,
+        message_for_main_agent=message_for_main_agent,
+    )

--- a/tests/unit/core/test_query_handoff.py
+++ b/tests/unit/core/test_query_handoff.py
@@ -1,0 +1,40 @@
+"""Tests for query handoff routing to the main agent."""
+
+from __future__ import annotations
+
+from tunacode.core.agents.main import RequestOrchestrator
+from tunacode.core.agents.query_handoff import build_query_handoff
+from tunacode.core.session import StateManager
+
+
+def test_build_query_handoff_routes_debug_queries() -> None:
+    handoff = build_query_handoff("Please debug this failing test")
+
+    assert handoff.route == "debug"
+    assert "Route: debug" in handoff.message_for_main_agent
+    assert "User query:" in handoff.message_for_main_agent
+
+
+def test_build_query_handoff_passes_commands_through() -> None:
+    handoff = build_query_handoff("/compact")
+
+    assert handoff.route == "command"
+    assert handoff.message_for_main_agent == "/compact"
+
+
+def test_request_orchestrator_keeps_user_message_and_handoff_message_distinct() -> None:
+    state_manager = StateManager()
+    message = "Add typed routing for incoming user query"
+
+    orchestrator = RequestOrchestrator(
+        message=message,
+        model="openai/gpt-4o",
+        state_manager=state_manager,
+        tool_callback=None,
+        streaming_callback=None,
+    )
+
+    assert orchestrator.user_message == message
+    assert orchestrator.handoff.route == "build"
+    assert orchestrator.message != message
+    assert "Route: build" in orchestrator.message


### PR DESCRIPTION
### Motivation

- Provide a tiny, typed pre-routing step to classify incoming user queries into intent buckets (`debug`, `build`, `explain`, `general`, `command`) so the main agent receives an explicit, compact handoff instead of raw text.
- Preserve the original user query for UI and task state so downstream behavior (e.g., empty-response follow-up and `task.original_query`) remains faithful to what the user typed.

### Description

- Add `src/tunacode/core/agents/query_handoff.py` which defines a frozen `QueryHandoff` dataclass and `build_query_handoff(query: str)` to classify queries and produce a compact `message_for_main_agent` or pass-through for slash commands.
- Wire `RequestOrchestrator` to compute `self.handoff = build_query_handoff(message)` and store `self.user_message = message`, then send `self.handoff.message_for_main_agent` into the agent stream while keeping `user_message` for `task.original_query` and empty-response prompts.
- Adjust empty-response and original-query logic to reference the preserved `user_message` rather than the rewritten handoff payload.
- Add focused unit tests in `tests/unit/core/test_query_handoff.py` for routing and command passthrough, and include a KB pattern card documenting the approach in `.claude/patterns/query-handoff-routing.md`.

### Testing

- Ran lint/format checks with `uv run ruff check --fix .` which completed successfully.
- Ran unit tests with `uv run pytest tests/unit/core/test_query_handoff.py tests/unit/core/test_thinking_stream_routing.py -q` and all tests passed (`7 passed` in ~1.5s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e96efaf288325a864cee5b35c938b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Query Handoff Routing

## State Management Changes
The PR introduces a three-layer message architecture in `RequestOrchestrator.__init__`:
- **`self.user_message`**: Preserves the original user input for task history and empty-response follow-up prompts
- **`self.handoff`**: A frozen `QueryHandoff` dataclass containing routing metadata (route, instruction, original_query)  
- **`self.message`**: The transformed `message_for_main_agent` sent to the main agent

The `_set_original_query_once()` method correctly uses `self.user_message` (not the transformed `self.message`) to populate `task.original_query`. Empty response intervention also properly references `self.user_message` when prompting the user, preserving intent distinction.

## Exception Handling
The `query_handoff.py` module contains **no explicit exception handling**. Error management relies on implicit fallback behavior:
- Empty or whitespace-only input safely returns "general" route via `query.strip()`
- No thrown exceptions for invalid input types
- Command passthrough for "/" prefixed queries is handled without validation

This implicit approach is safe but lacks explicit error paths or logging.

## Type Safety
**Strengths:**
- `QueryHandoff` dataclass immutably frozen with `slots=True` (memory efficient)
- Public API properly typed: `build_query_handoff(query: str) -> QueryHandoff`
- All dataclass fields have explicit type annotations (`str` for all fields)
- `RequestOrchestrator.__init__` signature unchanged; new attributes (`user_message`, `handoff`) are stateful, not API changes

**No regressions** to existing type contracts.

## Code Quality Concerns

**Substring Matching False Positives:**
Keyword routing uses substring containment (`keyword in lowered_query`) rather than word boundaries, causing unintended route assignments:
- "address this issue" → routes to "build" (contains "add")
- "unaddressed problem" → routes to "build" (contains "add")  
- "rebuild the code" → routes to "build" (contains "build" as substring)
- Multiple conflicting keywords route to first match in precedence order ("debug and build" → "debug")

**Test Coverage Gaps:**
- Only 3 unit tests covering basic happy paths
- Missing edge cases: whitespace normalization, overlapping keywords, boundary conditions
- Command passthrough not tested with surrounding whitespace

**No Dead Code Introduced:**
All new code is functional with no unused imports or unreachable paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->