### PR TITLE
style: tighten session inspector and simplify compaction UI

### DIFF
--- a/src/tunacode/ui/app.py
+++ b/src/tunacode/ui/app.py
@@ -41,7 +41,6 @@ from tunacode.core.ui_api.messaging import estimate_messages_tokens
 from tunacode.core.ui_api.shared_types import ModelName
 
 from tunacode.ui.context_panel import (
-    build_compaction_field,
     build_context_gauge,
     build_context_panel_widgets,
     build_files_field,
@@ -139,7 +138,6 @@ class TextualReplApp(App[None]):
         self._field_context: Static | None = None
         self._field_cost: Static | None = None
         self._field_files: Static | None = None
-        self._field_compaction: Static | None = None
         self._slopgotchi_state: SlopgotchiPanelState = SlopgotchiPanelState()
         self._field_slopgotchi: Static | None = None
         self._slopgotchi_handler: SlopgotchiHandler | None = None
@@ -177,7 +175,6 @@ class TextualReplApp(App[None]):
                 self._field_context = context_panel_widgets.field_context
                 self._field_cost = context_panel_widgets.field_cost
                 self._field_files = context_panel_widgets.field_files
-                self._field_compaction = context_panel_widgets.field_compaction
                 yield from context_panel_widgets.widgets
         yield self.editor
         yield FileAutoComplete(self.editor)
@@ -528,8 +525,6 @@ class TextualReplApp(App[None]):
 
     def _update_compaction_status(self, active: bool) -> None:
         self.resource_bar.update_compaction_status(active)
-        if self._field_compaction is not None:
-            self._field_compaction.update(build_compaction_field(is_compacting=active))
 
     def _update_resource_bar(self) -> None:
         session = self.state_manager.session

--- a/src/tunacode/ui/context_panel.py
+++ b/src/tunacode/ui/context_panel.py
@@ -35,7 +35,6 @@ class ContextPanelWidgets:
     field_context: InspectorField
     field_cost: InspectorField
     field_files: InspectorField
-    field_compaction: InspectorField
 
 
 def build_context_panel_widgets() -> ContextPanelWidgets:
@@ -74,20 +73,12 @@ def build_context_panel_widgets() -> ContextPanelWidgets:
     )
     field_files.border_title = "Files"
 
-    field_compaction = InspectorField(
-        "",
-        id="field-compaction",
-        classes="inspector-field",
-    )
-    field_compaction.border_title = "Compaction"
-
     widgets: tuple[Static, ...] = (
         field_slopgotchi,
         field_model,
         field_context,
         field_cost,
         field_files,
-        field_compaction,
     )
 
     return ContextPanelWidgets(
@@ -97,7 +88,6 @@ def build_context_panel_widgets() -> ContextPanelWidgets:
         field_context=field_context,
         field_cost=field_cost,
         field_files=field_files,
-        field_compaction=field_compaction,
     )
 
 
@@ -163,10 +153,3 @@ def is_widget_within_field(widget: DOMNode | None, root: DOMNode, *, field_id: s
         current = current.parent
 
     return False
-
-
-def build_compaction_field(*, is_compacting: bool) -> Text:
-    """Build compaction status display for context panel."""
-    if is_compacting:
-        return Text("Compacting...", style=f"bold {STYLE_WARNING}")
-    return Text("")

--- a/src/tunacode/ui/slopgotchi/panel.py
+++ b/src/tunacode/ui/slopgotchi/panel.py
@@ -11,10 +11,10 @@ from tunacode.ui.styles import STYLE_ERROR, STYLE_SUCCESS
 SLOPGOTCHI_NAME: str = "Slopgotchi"
 SLOPGOTCHI_HEART: str = "\u2665"
 SLOPGOTCHI_ART_STATES: tuple[str, str] = (
-    " /\\_/\\\n( T.T )\n > _ <",
-    " /\\_/\\\n( ;.; )\n > _ <",
+    " /\\_/\\\n( o.o )",
+    " /\\_/\\\n( -.- )",
 )
-SLOPGOTCHI_MOVE_RANGE: int = 4
+SLOPGOTCHI_MOVE_RANGE: int = 2
 SLOPGOTCHI_AUTO_MOVE_INTERVAL_SECONDS: float = 0.75
 
 

--- a/src/tunacode/ui/styles/layout.tcss
+++ b/src/tunacode/ui/styles/layout.tcss
@@ -62,9 +62,9 @@ ResourceBar.hidden {
  * The $surface background peeks between fields = depth cue.
  * ============================================ */
 #context-rail {
-    width: 40;
-    min-width: 32;
-    max-width: 52;
+    width: 34;
+    min-width: 28;
+    max-width: 44;
     height: 1fr;
     background: $surface;
     border-top: solid $bevel-light;
@@ -115,7 +115,7 @@ ResourceBar.hidden {
 
 /* Pet field - fixed height prevents panel shift during animation */
 #field-pet {
-    height: 6;
+    height: 4;
     padding: 0 1;
 }
 

--- a/tests/unit/ui/test_context_panel_toggle.py
+++ b/tests/unit/ui/test_context_panel_toggle.py
@@ -12,6 +12,7 @@ async def test_context_panel_toggle_ctrl_e() -> None:
     async with app.run_test(headless=True) as pilot:
         context_rail = app.query_one("#context-rail", Container)
         resource_bar = app.query_one(ResourceBar)
+        assert len(app.query("#field-compaction")) == 0
         assert not resource_bar.has_class(app.CONTEXT_PANEL_COLLAPSED_CLASS)
         assert context_rail.has_class(app.CONTEXT_PANEL_COLLAPSED_CLASS)
 


### PR DESCRIPTION
## Summary
- Remove the redundant Compaction field from the `ctrl+e` Session Inspector so compaction feedback stays in chat/notices instead of duplicated panel chrome.
- Keep compaction behavior and status callbacks intact while simplifying app wiring in the context panel path.
- Tighten Session Inspector sizing and reduce Slopgotchi footprint (smaller pet field, smaller art, reduced movement range) for a more compact right rail.

## Validation
- `uv run pytest tests/unit/ui/test_context_panel_toggle.py`
- `uv run ruff check src/tunacode/ui/slopgotchi/panel.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dead Code Removal

The PR cleanly removes the redundant Compaction field from the Session Inspector UI layer. The `build_compaction_field` helper function and `_field_compaction` attribute are eliminated with no orphaned references remaining in the codebase. The `ContextPanelWidgets` dataclass is simplified by removing the `field_compaction` field, with all construction sites properly updated.

## State Management Preservation

Compaction behavior and status callbacks are preserved in chat/notices as intended. No SessionState modifications are required, keeping application state management unchanged. The refactoring is purely a UI wiring simplification that does not affect core state handling.

## Type Safety

The dataclass field removal is cleanly propagated through all usages. The ContextPanelWidgets type surface is reduced with no type regressions introduced.

## Test Coverage

A verification assertion was added to the test suite (`len(app.query("#field-compaction")) == 0`) to ensure the compaction UI element is properly removed and prevent regression.

## UI Sizing Adjustments

Slopgotchi footprint is reduced: animation expressions updated (eye characters), movement range cut in half (4→2), pet field height reduced (6→4), and context rail dimensions tightened (width 40→34, min-width 32→28, max-width 52→44) to produce a more compact right rail layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->