### PR TITLE
fix: hide tool validation errors from users

### DIFF
--- a/.claude/delta/2026-03-03-ruff-import-order-determinism.md
+++ b/.claude/delta/2026-03-03-ruff-import-order-determinism.md
@@ -1,0 +1,45 @@
+---
+title: Make Ruff import sorting deterministic across local and CI
+type: delta
+link: ruff-import-order-determinism
+path: pyproject.toml
+depth: 1
+seams: [M]
+ontological_relations:
+  - affects: [[tooling]]
+  - affects: [[ci]]
+  - affects: [[imports]]
+tags:
+  - ruff
+  - pre-commit
+  - ci
+  - import-order
+created_at: 2026-03-03T04:30:00+00:00
+updated_at: 2026-03-03T04:30:00+00:00
+uuid: 1563860a-585a-49eb-a57a-52eb721c5912
+---
+
+# Make Ruff import sorting deterministic across local and CI
+
+## Summary
+
+Added `src = ["src"]` under `[tool.ruff]` so Ruff/isort classifies first-party modules from `src/` only.
+
+This prevents local environment differences (for example, an untracked `tinyAgent/` directory) from changing how `tinyagent` imports are grouped.
+
+Re-applied import sorting in files that were flipping between local and CI:
+
+- `src/tunacode/core/agents/agent_components/agent_config.py`
+- `src/tunacode/core/agents/main.py`
+- `src/tunacode/tools/decorators.py`
+- `tests/benchmarks/bench_discover.py`
+
+## Why
+
+PR #407 was failing the `pre-commit` GitHub check because Ruff auto-fixed imports in CI and exited with code 1.
+Local pre-commit passed after fixes, but CI still re-sorted imports due different module classification.
+
+## Validation
+
+- `uv run pre-commit run --all-files` ✅
+- `uv run pytest tests/integration/core/test_minimax_execution_path.py tests/integration/core/test_mtime_caches_end_to_end.py tests/system/cli/test_repl_support.py tests/unit/tools/test_tinyagent_tool_adapter.py -q` ✅

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ Documentation = "https://github.com/alchemiststudiosDOTai/tunacode#readme"
 
 [tool.ruff]
 line-length = 100
+src = ["src"]
 
 [tool.ruff.lint]
 select = [

--- a/src/tunacode/core/agents/agent_components/agent_config.py
+++ b/src/tunacode/core/agents/agent_components/agent_config.py
@@ -13,6 +13,7 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, cast
 
+from tinyagent import Agent, AgentOptions
 from tinyagent.agent_types import AgentMessage, AgentTool, AgentToolResult
 from tinyagent.alchemy_provider import OpenAICompatModel, stream_alchemy_openai_completions
 
@@ -47,8 +48,6 @@ from tunacode.infrastructure.cache.caches import tunacode_context as context_cac
 from tunacode.core.compaction.controller import get_or_create_compaction_controller
 from tunacode.core.logging import get_logger
 from tunacode.core.types import SessionStateProtocol, StateManagerProtocol
-
-from tinyagent import Agent, AgentOptions
 
 ENV_OPENAI_API_KEY = "OPENAI_API_KEY"
 OPENAI_CHAT_COMPLETIONS_PATH = "/chat/completions"

--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -10,6 +10,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, cast
 
+from tinyagent import Agent
+
 from tunacode.constants import DEFAULT_CONTEXT_WINDOW
 from tunacode.exceptions import (
     AgentError,
@@ -38,8 +40,6 @@ from tunacode.core.compaction.types import CompactionOutcome
 from tunacode.core.debug import log_usage_update
 from tunacode.core.logging import get_logger
 from tunacode.core.types import RuntimeState, StateManagerProtocol
-
-from tinyagent import Agent
 
 from . import agent_components as ac
 from .helpers import (
@@ -717,9 +717,8 @@ class RequestOrchestrator:
 
 def get_agent_tool() -> tuple[type[Any], type[Any]]:
     """Return the (Agent, AgentTool) classes."""
-    from tinyagent.agent_types import AgentTool as ToolCls
-
     from tinyagent import Agent as AgentCls
+    from tinyagent.agent_types import AgentTool as ToolCls
 
     return AgentCls, ToolCls
 

--- a/src/tunacode/tools/decorators.py
+++ b/src/tunacode/tools/decorators.py
@@ -154,10 +154,10 @@ def to_tinyagent_tool(
         A tinyAgent ``AgentTool``.
     """
 
+    from tinyagent import AgentTool, AgentToolResult
+
     from tunacode.prompts.versioning import get_or_compute_prompt_version
     from tunacode.types.canonical import PromptVersion
-
-    from tinyagent import AgentTool, AgentToolResult
 
     tool_name = name or func.__name__
     tool_label = label or tool_name

--- a/tests/benchmarks/bench_discover.py
+++ b/tests/benchmarks/bench_discover.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from tinyagent import AgentTool
+
 from tunacode.tools.cache_accessors.ignore_manager_cache import clear_ignore_manager_cache
 from tunacode.tools.cache_accessors.ripgrep_cache import clear_ripgrep_cache
 from tunacode.tools.cache_accessors.xml_prompts_cache import clear_xml_prompts_cache
@@ -37,8 +39,6 @@ from tunacode.tools.discover import _extract_search_terms, discover
 from tunacode.tools.ignore import get_ignore_manager
 from tunacode.tools.read_file import read_file
 from tunacode.tools.utils.ripgrep import RipgrepExecutor
-
-from tinyagent import AgentTool
 
 # ---------------------------------------------------------------------------
 # Constants


### PR DESCRIPTION
## Summary

- Filter out tool argument validation errors from UI display (e.g., "missing required argument")
- These errors go back to the model for retry, not shown to users
- Clean up error messages by removing schema dump

## Problem

When models like MiniMax-M2.1 make malformed tool calls (e.g., calling `discover` without the required `query` argument), users see confusing error panels with JSON schema dumps:

```
Invalid arguments for tool 'discover': missing a required argument: 'query'. 
Expected schema: {'type': 'object', 'properties': {...}}
```

## Solution

1. **Cleaner error message** - Removed the schema dump from the error, keeping just:
   ```
   Invalid arguments for tool 'discover': missing a required argument: 'query'
   ```

2. **UI filtering** - Added `_is_validation_error()` check in `build_tool_result_callback()` to skip posting validation errors to the UI. The model still receives the error in conversation history and can retry.

## Files Changed

- `src/tunacode/tools/decorators.py` - Cleaner error message
- `src/tunacode/ui/repl_support.py` - Filter validation errors from UI

## Test Plan

- [ ] Tool validation errors are hidden from users
- [ ] Model still receives errors and can retry
- [ ] Other tool failures (e.g., file not found) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Summary
- Hide tool argument validation errors from the UI while preserving them in the conversation returned to the model so the model can retry. Validation error messages no longer include JSON/schema dumps; they're cleaned to a concise message (e.g., "Invalid arguments for tool 'discover': missing a required argument: 'query'").

State management (SessionState, messages, tool calls)
- No changes to SessionState or core tool-call plumbing.
- UI messaging flow: build_tool_result_callback now suppresses posting validation-error results to the UI by early-return when status == "failed" and the result matches _is_validation_error(result). The callback still updates status bar state (complete_running_action, update_last_action) and preserves truncation/posting behavior for all other results.
- Tool execution wiring (to_tinyagent_tool → AgentTool.execute) remains unchanged in control flow; tool errors are still propagated back to the agent loop for model consumption.

Exception handling paths
- to_tinyagent_tool.execute:
  - Maintains the arg-type check (non-dict args → ToolRetryError).
  - Signature binding TypeError handling simplified: previously included a full parameters/schema dump in the error message — now raises ToolRetryError with a concise message "Invalid arguments for tool '{tool_name}': {exc}" (schema dump removed).
  - File-tool-specific mappings (FileNotFoundError → ToolRetryError; PermissionError/UnicodeDecodeError/OSError → FileOperationError) remain unchanged in file_tool/base_tool wrappers.
- High-level error classes (ToolRetryError, ToolExecutionError, FileOperationError, UserAbortError) and their propagation behavior are preserved.

Type safety
- No changes to public/exported function signatures.
- AgentTool and AgentToolResult imports were moved inside to_tinyagent_tool (localized import) — reordering only; no external API or typing changes.
- Bound.arguments are still cast to dict[str, Any] before invoking the tool; typing usage remains the same.
- The new _is_validation_error(result: str | None) is a small, type-annotated predicate used only to identify validation errors for UI suppression.

Dead code / message cleanup
- Removed verbose schema dump embedded in the TypeError->ToolRetryError message (cleaner error text). No dead code introduced; no other content removed.

Tests
- Integration test updates adjust monkeypatch return shapes (load_system_prompt/load_tunacode_context now patched to return ("", None)) and indexing expectations (tests index into the first element of returned tuples/results). These changes align with internal return-shape expectations and do not alter the intent of validation-suppression behavior tests.
- No tests removed; updated assertions reflect changed return structures.

Risk / Follow-ups
- Validation detection uses a conservative substring check in _is_validation_error ("Invalid arguments for tool" and "missing a required argument"). Consider hardening/expanding detection (or exporting a canonical error type/tag) to avoid false negatives/positives for other validation phrasing.
- Ensure unit/integration coverage for edge cases where non-validation errors might contain similar substrings and for additional validation message formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->