### PR TITLE
fix: align bash timeout contract to seconds

### DIFF
--- a/src/tunacode/tools/bash.py
+++ b/src/tunacode/tools/bash.py
@@ -14,6 +14,9 @@ COMMAND_OUTPUT_THRESHOLD = 3500
 COMMAND_OUTPUT_START_INDEX = 2500
 COMMAND_OUTPUT_END_SIZE = 1000
 CMD_OUTPUT_TRUNCATED = "\n...\n[truncated]\n...\n"
+MIN_TIMEOUT_SECONDS = 1
+MAX_TIMEOUT_SECONDS = 300
+DEFAULT_TIMEOUT_SECONDS = 30
 
 
 @base_tool
@@ -21,7 +24,7 @@ async def bash(
     command: str,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
-    timeout: int | None = 30,
+    timeout: int | None = DEFAULT_TIMEOUT_SECONDS,
     capture_output: bool = True,
 ) -> str:
     """Execute a bash command with enhanced features.
@@ -90,9 +93,9 @@ def _validate_inputs(command: str, cwd: str | None, timeout: int | None) -> None
     if not command.strip():
         raise ToolRetryError("Empty command not allowed")
 
-    if timeout and (timeout < 1 or timeout > 300):
+    if timeout is not None and (timeout < MIN_TIMEOUT_SECONDS or timeout > MAX_TIMEOUT_SECONDS):
         raise ToolRetryError(
-            "Timeout must be between 1 and 300 seconds. "
+            f"Timeout must be between {MIN_TIMEOUT_SECONDS} and {MAX_TIMEOUT_SECONDS} seconds. "
             "Use shorter timeouts for quick commands, longer for builds/tests."
         )
 

--- a/src/tunacode/tools/prompts/bash_prompt.xml
+++ b/src/tunacode/tools/prompts/bash_prompt.xml
@@ -5,6 +5,7 @@ Execute bash commands. Use for git, npm, docker, and system operations.
 - Quote paths with spaces: cd "/path with spaces"
 - Chain commands with &amp;&amp; or ;
 - Use the discover tool for code search instead of grep/find/ls
-- Optional timeout in milliseconds (default 120000, max 600000)
+- Optional timeout in seconds (default 30, range 1-300)
+- Example: timeout=60 for a long-running build/test command
     </description>
 </tool_prompt>

--- a/tests/unit/tools/test_bash.py
+++ b/tests/unit/tools/test_bash.py
@@ -1,0 +1,40 @@
+"""Tests for bash tool timeout validation and prompt contract."""
+
+import pytest
+
+from tunacode.exceptions import ToolRetryError
+
+from tunacode.tools.bash import bash
+from tunacode.tools.cache_accessors.xml_prompts_cache import clear_xml_prompts_cache
+from tunacode.tools.xml_helper import load_prompt_from_xml
+
+
+class TestBashTimeoutValidation:
+    async def test_rejects_zero_timeout(self) -> None:
+        with pytest.raises(ToolRetryError, match="between 1 and 300 seconds"):
+            await bash(command="printf ok", timeout=0)
+
+    async def test_rejects_millisecond_timeout_value(self) -> None:
+        with pytest.raises(ToolRetryError, match="between 1 and 300 seconds"):
+            await bash(command="printf ok", timeout=60000)
+
+    async def test_accepts_minimum_timeout(self) -> None:
+        result = await bash(command="printf ok", timeout=1)
+        assert "Exit Code: 0" in result
+
+    async def test_accepts_maximum_timeout(self) -> None:
+        result = await bash(command="printf ok", timeout=300)
+        assert "Exit Code: 0" in result
+
+
+class TestBashPromptContract:
+    def test_bash_prompt_documents_seconds_not_milliseconds(self) -> None:
+        clear_xml_prompts_cache()
+        prompt = load_prompt_from_xml("bash")
+
+        assert isinstance(prompt, str)
+        prompt_lower = prompt.lower()
+        assert "timeout in seconds" in prompt_lower
+        assert "default 30" in prompt_lower
+        assert "1-300" in prompt_lower
+        assert "milliseconds" not in prompt_lower


### PR DESCRIPTION
## Summary
- align the bash tool prompt contract with runtime validation by documenting timeout in seconds (default 30, range 1-300) instead of milliseconds
- harden timeout validation to reject `timeout=0` by checking `timeout is not None`, and replace magic timeout literals with named constants
- add unit tests covering timeout bounds and a prompt-contract regression test to prevent seconds/milliseconds drift

## Validation
- `uv run pytest tests/unit/tools/test_bash.py -q`
- `uv run ruff check src/tunacode/tools/bash.py tests/unit/tools/test_bash.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Exception Handling Paths

The PR hardens timeout validation with explicit error handling:
- Introduces an explicit `timeout is not None` check in input validation to ensure `timeout=0` is rejected
- Updated `ToolRetryError` messages to reflect the new timeout contract (seconds instead of milliseconds), with messages now containing "between 1 and 300 seconds"
- Added test coverage validating that both zero timeout and millisecond-based values (e.g., 60000) are properly rejected with the updated error message

## Type Safety & Constants

Three module-level constants replace magic literals:
- `MIN_TIMEOUT_SECONDS = 1`
- `MAX_TIMEOUT_SECONDS = 300`  
- `DEFAULT_TIMEOUT_SECONDS = 30`

The function signature remains `timeout: int | None` with default updated to use the `DEFAULT_TIMEOUT_SECONDS` constant, improving maintainability without changing the type contract.

## Validation & Contract Alignment

The prompt documentation and runtime validation are now aligned:
- Timeout is consistently documented and validated in seconds (not milliseconds)
- Validation logic uses the new constants to enforce bounds [1, 300]
- New regression test in the test suite ensures the bash prompt contains "timeout in seconds", "default 30", and "1-300", with explicit assertion that "milliseconds" is absent—preventing future seconds/milliseconds mismatches

## Test Coverage

Added new unit tests covering:
- Timeout bounds validation (minimum 1 second, maximum 300 seconds)
- Rejection of invalid values (zero, millisecond-based timeouts)
- Prompt contract verification against the loaded bash XML prompt

<!-- end of auto-generated comment: release notes by coderabbit.ai -->