### PR TITLE
fix: retry update against active Python for uv tool installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-03-12
+Last Updated: 2026-03-13
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.

--- a/src/tunacode/ui/commands/update.py
+++ b/src/tunacode/ui/commands/update.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shutil
+import sys
 from typing import TYPE_CHECKING
 
 from tunacode.ui.commands.base import Command
@@ -19,8 +21,6 @@ def _is_tool_install() -> bool:
     Returns True when the install looks like pipx or ``uv tool`` (the
     executable lives under a path that contains a tool-managed venv).
     """
-    import sys
-
     exe = sys.executable
     # pipx venvs:   ~/.local/pipx/venvs/<pkg>/...
     # uv tool:      ~/.local/share/uv/tools/<pkg>/...
@@ -38,8 +38,6 @@ def _get_package_manager_command(package: str) -> tuple[list[str], str] | None:
     Returns:
         tuple(list[str], str) for command and manager name, or None if unavailable.
     """
-    import shutil
-
     if _is_tool_install():
         uv_path = shutil.which("uv")
         if uv_path:
@@ -60,6 +58,64 @@ def _get_package_manager_command(package: str) -> tuple[list[str], str] | None:
     return None
 
 
+def _should_retry_uv_tool_with_active_python(stderr: str) -> bool:
+    """Return True when uv tool cannot locate the currently running install."""
+    normalized_stderr = stderr.strip()
+    return "is not installed; run `uv tool install" in normalized_stderr
+
+
+def _get_active_python_upgrade_command(package: str) -> tuple[list[str], str] | None:
+    """Build a direct upgrade command against the active interpreter."""
+    uv_path = shutil.which("uv")
+    if uv_path:
+        return (
+            [uv_path, "pip", "install", "--python", sys.executable, "--upgrade", package],
+            "uv pip",
+        )
+
+    return None
+
+
+async def _run_upgrade_command(
+    app: TextualReplApp,
+    cmd: list[str],
+    pkg_mgr: str,
+    package: str,
+) -> tuple[int, str]:
+    """Run the selected upgrade command and retry against the active interpreter when needed."""
+    import asyncio
+    import subprocess
+
+    result = await asyncio.to_thread(
+        subprocess.run,
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=UPDATE_INSTALL_TIMEOUT_SECONDS,
+    )
+
+    if result.returncode == 0 or pkg_mgr != "uv tool":
+        return result.returncode, result.stderr.strip()
+
+    fallback_cmd_result = _get_active_python_upgrade_command(package)
+    if not fallback_cmd_result or not _should_retry_uv_tool_with_active_python(result.stderr):
+        return result.returncode, result.stderr.strip()
+
+    fallback_cmd, fallback_mgr = fallback_cmd_result
+    app.chat_container.write(
+        "uv tool could not locate this install; "
+        f"retrying with {fallback_mgr} against the active Python..."
+    )
+    fallback_result = await asyncio.to_thread(
+        subprocess.run,
+        fallback_cmd,
+        capture_output=True,
+        text=True,
+        timeout=UPDATE_INSTALL_TIMEOUT_SECONDS,
+    )
+    return fallback_result.returncode, fallback_result.stderr.strip()
+
+
 class UpdateCommand(Command):
     """Check for and install updates to tunacode."""
 
@@ -69,7 +125,6 @@ class UpdateCommand(Command):
 
     async def execute(self, app: TextualReplApp, _args: str) -> None:
         import asyncio
-        import subprocess
 
         from tunacode.core.ui_api.system_paths import (
             check_for_updates,
@@ -109,19 +164,18 @@ class UpdateCommand(Command):
 
             async def install_update() -> None:
                 try:
-                    result = await asyncio.to_thread(
-                        subprocess.run,
+                    returncode, stderr = await _run_upgrade_command(
+                        app,
                         cmd,
-                        capture_output=True,
-                        text=True,
-                        timeout=UPDATE_INSTALL_TIMEOUT_SECONDS,
+                        pkg_mgr,
+                        PACKAGE_NAME,
                     )
 
-                    if result.returncode == 0:
+                    if returncode == 0:
                         msg = f"Updated to {latest_version}! Restart tunacode to use it."
                         app.chat_container.write(msg)
                     else:
-                        app.chat_container.write(f"Update failed: {result.stderr.strip()}")
+                        app.chat_container.write(f"Update failed: {stderr}")
                 except Exception as e:
                     app.chat_container.write(f"Error: {e}")
 

--- a/tests/unit/ui/test_update_command.py
+++ b/tests/unit/ui/test_update_command.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from tunacode.ui.commands import update
+
+
+def test_should_retry_uv_tool_with_active_python_for_missing_tool_error() -> None:
+    stderr = (
+        "Failed to upgrade tunacode-cli\n"
+        "Caused by: `tunacode-cli` is not installed; run `uv tool install tunacode-cli` to install"
+    )
+
+    assert update._should_retry_uv_tool_with_active_python(stderr) is True
+
+
+def test_should_not_retry_uv_tool_with_active_python_for_other_errors() -> None:
+    stderr = "error: network timeout"
+
+    assert update._should_retry_uv_tool_with_active_python(stderr) is False
+
+
+def test_get_active_python_upgrade_command_uses_current_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_python = "/tmp/tool-venv/bin/python"
+    fake_uv = "/usr/local/bin/uv"
+
+    monkeypatch.setattr(update.sys, "executable", fake_python)
+    monkeypatch.setattr(update.shutil, "which", lambda name: fake_uv if name == "uv" else None)
+
+    cmd_result = update._get_active_python_upgrade_command("tunacode-cli")
+
+    assert cmd_result == (
+        [fake_uv, "pip", "install", "--python", fake_python, "--upgrade", "tunacode-cli"],
+        "uv pip",
+    )
+
+
+def test_get_active_python_upgrade_command_returns_none_without_uv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update.shutil, "which", lambda _name: None)
+
+    assert update._get_active_python_upgrade_command("tunacode-cli") is None


### PR DESCRIPTION
## Summary
- retry `/update` via `uv pip install --python <active interpreter>` when `uv tool upgrade` cannot find the current install
- keep the original `uv tool` flow for normal success/error cases and surface a retry message in the UI
- add unit coverage for the retry detection and active-Python fallback command builder

## Testing
- uv run pytest tests/unit/ui/test_update_command.py
- uv run python scripts/check_agents_freshness.py