### PR TITLE
perf: reduce TUI cold-start overhead

### DIFF
--- a/src/tunacode/core/session/state.py
+++ b/src/tunacode/core/session/state.py
@@ -6,31 +6,28 @@ Handles user preferences, conversation history, and runtime state.
 CLAUDE_ANCHOR[state-module]: Central state management and session tracking
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import ValidationError
-from tinyagent.agent_types import (
-    AgentMessage,
-    AssistantMessage,
-    CustomAgentMessage,
-    ToolResultMessage,
-    UserMessage,
-)
 
 from tunacode.configuration.defaults import DEFAULT_USER_CONFIG
 from tunacode.types import InputSessions, ModelName, SessionId, UserConfig
 from tunacode.types.canonical import UsageMetrics
 
-from tunacode.core.compaction.types import CompactionRecord
 from tunacode.core.types import ConversationState, RuntimeState, TaskState, UsageState
 
-_AGENT_MESSAGE_TYPES = UserMessage, AssistantMessage, ToolResultMessage, CustomAgentMessage
+if TYPE_CHECKING:
+    from tinyagent.agent_types import AgentMessage
+
+    from tunacode.core.compaction.types import CompactionRecord
 
 
 @dataclass
@@ -74,6 +71,17 @@ class SessionState:
     # Streaming debug instrumentation (see core/agents/agent_components/streaming.py)
     _debug_events: list[str] = field(default_factory=list)
     _debug_raw_stream_accum: str = ""
+
+
+def _agent_message_types() -> tuple[type[object], ...]:
+    from tinyagent.agent_types import (
+        AssistantMessage,
+        CustomAgentMessage,
+        ToolResultMessage,
+        UserMessage,
+    )
+
+    return (UserMessage, AssistantMessage, ToolResultMessage, CustomAgentMessage)
 
 
 class StateManager:
@@ -173,16 +181,21 @@ class StateManager:
     def _serialize_messages(self) -> list[dict[str, Any]]:
         """Serialize in-memory tinyagent message models to JSON dictionaries."""
 
+        messages = self._session.conversation.messages
+        if not messages:
+            return []
+
         serialized_messages: list[dict[str, Any]] = []
-        for idx, message in enumerate(self._session.conversation.messages):
-            if not isinstance(message, _AGENT_MESSAGE_TYPES):
+        agent_message_types = _agent_message_types()
+        for idx, message in enumerate(messages):
+            if not isinstance(message, agent_message_types):
                 message_type = type(message).__name__
                 raise TypeError(
                     "Session messages must be tinyagent message models; "
                     f"found {message_type} at index {idx}"
                 )
 
-            serialized_message = message.model_dump(exclude_none=True)
+            serialized_message = cast(Any, message).model_dump(exclude_none=True)
             if not isinstance(serialized_message, dict):
                 raise TypeError(
                     "Session message model_dump(exclude_none=True) must return dict; "
@@ -194,6 +207,13 @@ class StateManager:
         return serialized_messages
 
     def _deserialize_message(self, raw_message: Any, *, index: int) -> AgentMessage:
+        from tinyagent.agent_types import (
+            AssistantMessage,
+            CustomAgentMessage,
+            ToolResultMessage,
+            UserMessage,
+        )
+
         if not isinstance(raw_message, dict):
             raise TypeError(
                 "Session messages must be tinyagent JSON objects; "
@@ -240,6 +260,8 @@ class StateManager:
         return record.to_dict()
 
     def _deserialize_compaction(self, data: Any) -> CompactionRecord | None:
+        from tunacode.core.compaction.types import CompactionRecord
+
         if data is None:
             return None
 

--- a/src/tunacode/core/types/__init__.py
+++ b/src/tunacode/core/types/__init__.py
@@ -1,14 +1,25 @@
 """Core-specific type exports."""
 
-from tunacode.core.types.agent_state import AgentState, ResponseState  # noqa: F401
-from tunacode.core.types.state import (  # noqa: F401
-    SessionStateProtocol,
-    StateManagerProtocol,
-)
-from tunacode.core.types.state_structures import (  # noqa: F401
-    ConversationState,
-    RuntimeState,
-    TaskState,
-    UsageState,
-)
-from tunacode.core.types.tool_registry import ToolCallRegistry  # noqa: F401
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_TYPE_EXPORTS = {
+    "AgentState": ".agent_state",
+    "ResponseState": ".agent_state",
+    "SessionStateProtocol": ".state",
+    "StateManagerProtocol": ".state",
+    "ConversationState": ".state_structures",
+    "RuntimeState": ".state_structures",
+    "TaskState": ".state_structures",
+    "UsageState": ".state_structures",
+    "ToolCallRegistry": ".tool_registry",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _TYPE_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_name, __name__), name)

--- a/src/tunacode/core/types/state_structures.py
+++ b/src/tunacode/core/types/state_structures.py
@@ -3,15 +3,31 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from tinyagent.agent_types import AgentMessage
+if TYPE_CHECKING:
+    from tinyagent.agent_types import AgentMessage
 
-from tunacode.types.canonical import UsageMetrics
+    from tunacode.types.canonical import UsageMetrics
 
-from tunacode.core.types.tool_registry import ToolCallRegistry
+    from tunacode.core.types.tool_registry import ToolCallRegistry
 
-MessageHistory = list[AgentMessage]
+    MessageHistory = list[AgentMessage]
+else:
+    MessageHistory = list[Any]
+
+
+def _build_tool_call_registry() -> ToolCallRegistry:
+    from tunacode.core.types.tool_registry import ToolCallRegistry
+
+    return ToolCallRegistry()
+
+
+def _build_usage_metrics() -> UsageMetrics:
+    from tunacode.types.canonical import UsageMetrics
+
+    return UsageMetrics()
+
 
 DEFAULT_BATCH_COUNTER = 0
 DEFAULT_CONSECUTIVE_EMPTY_RESPONSES = 0
@@ -50,7 +66,7 @@ class RuntimeState:
     request_id: str = DEFAULT_REQUEST_ID
     consecutive_empty_responses: int = DEFAULT_CONSECUTIVE_EMPTY_RESPONSES
     batch_counter: int = DEFAULT_BATCH_COUNTER
-    tool_registry: ToolCallRegistry = field(default_factory=ToolCallRegistry)
+    tool_registry: ToolCallRegistry = field(default_factory=_build_tool_call_registry)
     operation_cancelled: bool = False
     is_streaming_active: bool = False
     streaming_panel: Any | None = None
@@ -60,5 +76,5 @@ class RuntimeState:
 class UsageState:
     """Usage metrics for last call and cumulative session totals."""
 
-    last_call_usage: UsageMetrics = field(default_factory=UsageMetrics)
-    session_total_usage: UsageMetrics = field(default_factory=UsageMetrics)
+    last_call_usage: UsageMetrics = field(default_factory=_build_usage_metrics)
+    session_total_usage: UsageMetrics = field(default_factory=_build_usage_metrics)

--- a/src/tunacode/ui/__init__.py
+++ b/src/tunacode/ui/__init__.py
@@ -1,4 +1,18 @@
-"""TunaCode UI layer - Textual-based TUI."""
+"""TunaCode UI layer - Textual-based TUI.
 
-from .app import TextualReplApp  # noqa: F401
-from .repl_support import run_textual_repl  # noqa: F401
+Keep package import thin so submodules like ``tunacode.ui.main`` do not pay for
+full Textual app imports unless they actually need them.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name == "TextualReplApp":
+        return importlib.import_module(".app", __name__).TextualReplApp
+    if name == "run_textual_repl":
+        return importlib.import_module(".repl_support", __name__).run_textual_repl
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/tunacode/ui/app.py
+++ b/src/tunacode/ui/app.py
@@ -9,7 +9,6 @@ import time
 from typing import TYPE_CHECKING, Never
 
 from rich.console import RenderableType
-from rich.markdown import Markdown
 from rich.text import Text
 from textual import events
 from textual.app import App, ComposeResult
@@ -17,19 +16,14 @@ from textual.binding import Binding
 from textual.containers import Container
 from textual.timer import Timer
 from textual.widgets import LoadingIndicator, Static
-from tinyagent.agent_types import AssistantMessage, TextContent, UserMessage
 
 if TYPE_CHECKING:
     from textual.theme import Theme
 
+    from tunacode.core.session import StateManager
     from tunacode.ui.lifecycle import AppLifecycle
+    from tunacode.ui.shell_runner import ShellRunner
 
-from tunacode.skills.selection import resolve_selected_skill_summaries
-
-from tunacode.core.agents.main import process_request
-from tunacode.core.debug import log_resource_bar_update
-from tunacode.core.logging import get_logger
-from tunacode.core.session import StateManager
 from tunacode.core.ui_api.constants import (
     MIN_TOOL_PANEL_LINE_WIDTH,
     RESOURCE_BAR_COST_FORMAT,
@@ -41,10 +35,6 @@ from tunacode.core.ui_api.constants import (
     build_tunacode_theme,
     wrap_builtin_themes,
 )
-from tunacode.core.ui_api.messaging import estimate_messages_tokens
-from tunacode.core.ui_api.shared_types import ModelName
-
-from tunacode.ui.clipboard import copy_selection_to_clipboard
 from tunacode.ui.context_panel import (
     build_context_gauge,
     build_context_panel_widgets,
@@ -55,9 +45,6 @@ from tunacode.ui.context_panel import (
     token_remaining_pct,
 )
 from tunacode.ui.esc.handler import EscHandler
-from tunacode.ui.model_display import format_model_for_display
-from tunacode.ui.renderers.errors import render_exception
-from tunacode.ui.renderers.panels import tool_panel_smart
 from tunacode.ui.renderers.thinking import (
     DEFAULT_THINKING_MAX_CHARS,
     DEFAULT_THINKING_MAX_LINES,
@@ -69,7 +56,6 @@ from tunacode.ui.repl_support import (
     format_user_message,
     normalize_agent_message_text,
 )
-from tunacode.ui.shell_runner import ShellRunner
 from tunacode.ui.slopgotchi import (
     SlopgotchiHandler,
     SlopgotchiPanelState,
@@ -86,6 +72,13 @@ from tunacode.ui.widgets import (
     SkillsAutoComplete,
     ToolResultDisplay,
 )
+
+
+def copy_selection_to_clipboard(app: App[None], show_toast: bool = True) -> str | None:
+    """Lazily import clipboard helpers to avoid startup cost on launch."""
+    from tunacode.ui.clipboard import copy_selection_to_clipboard as _copy_selection_to_clipboard
+
+    return _copy_selection_to_clipboard(app, show_toast=show_toast)
 
 
 class TextualReplApp(App[None]):
@@ -132,7 +125,7 @@ class TextualReplApp(App[None]):
         self._loading_indicator_shown: bool = False
         self._request_start_time: float = 0.0
         self._esc_handler: EscHandler = EscHandler()
-        self.shell_runner = ShellRunner(self)
+        self._shell_runner: ShellRunner | None = None
         self.chat_container: ChatContainer
         self.editor: Editor
         self.resource_bar: ResourceBar
@@ -195,6 +188,16 @@ class TextualReplApp(App[None]):
             if theme_name in self.available_themes
         }
 
+    @property
+    def shell_runner(self) -> ShellRunner:
+        shell_runner = self._shell_runner
+        if shell_runner is None:
+            from tunacode.ui.shell_runner import ShellRunner
+
+            shell_runner = ShellRunner(self)
+            self._shell_runner = shell_runner
+        return shell_runner
+
     def on_mount(self) -> None:
         from tunacode.ui.lifecycle import AppLifecycle
 
@@ -214,6 +217,8 @@ class TextualReplApp(App[None]):
             try:
                 await self._process_request(request)
             except Exception as e:
+                from tunacode.ui.renderers.errors import render_exception
+
                 content, meta = render_exception(e)
                 self.chat_container.write(content, panel_meta=meta)
             finally:
@@ -245,6 +250,9 @@ class TextualReplApp(App[None]):
             model_name = session.current_model or "openai/gpt-4o"
             should_stream_agent_text = self._should_stream_agent_text()
             streaming_callback = self.streaming.callback if should_stream_agent_text else None
+            from tunacode.core.agents.main import process_request
+            from tunacode.core.ui_api.shared_types import ModelName
+
             self._current_request_task = asyncio.create_task(
                 process_request(
                     message=message,
@@ -263,6 +271,8 @@ class TextualReplApp(App[None]):
         except asyncio.CancelledError:
             self.notify("Cancelled")
         except Exception as e:
+            from tunacode.ui.renderers.errors import render_exception
+
             content, meta = render_exception(e)
             self.chat_container.write(content, panel_meta=meta)
         finally:
@@ -295,6 +305,8 @@ class TextualReplApp(App[None]):
             await self.state_manager.save_session()
 
     def _get_latest_response_text(self) -> str | None:
+        from tinyagent.agent_types import AssistantMessage, TextContent
+
         messages = self.state_manager.session.conversation.messages
         for message in reversed(messages):
             if not isinstance(message, AssistantMessage):
@@ -334,6 +346,8 @@ class TextualReplApp(App[None]):
         self.chat_container.write(user_block).add_class("user-message")
 
     def on_tool_result_display(self, message: ToolResultDisplay) -> None:
+        from tunacode.ui.renderers.panels import tool_panel_smart
+
         max_line_width = self.tool_panel_max_width()
         content, panel_meta = tool_panel_smart(
             name=message.tool_name,
@@ -378,6 +392,9 @@ class TextualReplApp(App[None]):
 
     def _replay_session_messages(self) -> None:
         """Render loaded session messages to ChatContainer."""
+        from rich.markdown import Markdown
+        from tinyagent.agent_types import AssistantMessage, UserMessage
+
         from tunacode.core.ui_api.messaging import get_content
 
         conversation = self.state_manager.session.conversation
@@ -444,10 +461,9 @@ class TextualReplApp(App[None]):
         """Cancel the current request or shell command."""
         esc_handler = self._esc_handler
         current_request_task = self._current_request_task
-        shell_runner = getattr(self, "shell_runner", None)
         esc_handler.handle_escape(
             current_request_task=current_request_task,
-            shell_runner=shell_runner,
+            shell_runner=getattr(self, "_shell_runner", None),
         )
 
     def start_shell_command(self, raw_cmd: str) -> None:
@@ -474,11 +490,13 @@ class TextualReplApp(App[None]):
             or field_skills is None
         ):
             return
+        from tunacode.ui.model_display import format_model_for_display
+
         session = self.state_manager.session
         conversation = session.conversation
         raw_model = session.current_model or ""
         model_display = format_model_for_display(raw_model, max_length=30) if raw_model else "---"
-        estimated_tokens = estimate_messages_tokens(conversation.messages)
+        estimated_tokens = self._estimate_conversation_tokens(conversation.messages)
         max_tokens = conversation.max_tokens or self.DEFAULT_CONTEXT_MAX_TOKENS
         remaining_pct = token_remaining_pct(estimated_tokens, max_tokens)
         current_token_style = token_color(remaining_pct)
@@ -507,7 +525,17 @@ class TextualReplApp(App[None]):
         if handler is not None:
             handler._refresh()
 
+    def _estimate_conversation_tokens(self, messages: list[object]) -> int:
+        if not messages:
+            return 0
+
+        from tunacode.core.ui_api.messaging import estimate_messages_tokens
+
+        return estimate_messages_tokens(messages)
+
     def _build_skill_entries(self) -> list[tuple[str, str]]:
+        from tunacode.skills.selection import resolve_selected_skill_summaries
+
         skill_entries: list[tuple[str, str]] = []
         resolved_summaries = resolve_selected_skill_summaries(
             self.state_manager.session.selected_skill_names
@@ -539,10 +567,13 @@ class TextualReplApp(App[None]):
         self.resource_bar.update_compaction_status(active)
 
     def _update_resource_bar(self) -> None:
+        from tunacode.core.debug import log_resource_bar_update
+        from tunacode.core.logging import get_logger
+
         session = self.state_manager.session
         conversation = session.conversation
         # Use simplified token counter to estimate actual context window usage
-        estimated_tokens = estimate_messages_tokens(conversation.messages)
+        estimated_tokens = self._estimate_conversation_tokens(conversation.messages)
         model = session.current_model or "No model selected"
         max_tokens = conversation.max_tokens or self.DEFAULT_CONTEXT_MAX_TOKENS
         session_cost = session.usage.session_total_usage.cost.total
@@ -560,7 +591,8 @@ class TextualReplApp(App[None]):
             max_tokens=max_tokens,
             session_cost=session_cost,
         )
-        self._refresh_context_panel()
+        if self._context_panel_visible:
+            self._refresh_context_panel()
 
     def _hide_thinking_output(self) -> None:
         from tunacode.ui.thinking_state import hide_thinking_output

--- a/src/tunacode/ui/command_registry.py
+++ b/src/tunacode/ui/command_registry.py
@@ -1,0 +1,78 @@
+"""Lazy slash-command registry for TunaCode REPL."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tunacode.ui.commands.base import Command
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSpec:
+    module_name: str
+    class_name: str
+    description: str
+
+
+_COMMAND_SPECS: dict[str, CommandSpec] = {
+    "help": CommandSpec("help", "HelpCommand", "Show available commands"),
+    "cancel": CommandSpec("cancel", "CancelCommand", "Cancel current request"),
+    "clear": CommandSpec("clear", "ClearCommand", "Clear chat history display"),
+    "compact": CommandSpec(
+        "compact",
+        "CompactCommand",
+        "Summarize old context and keep recent messages",
+    ),
+    "debug": CommandSpec("debug", "DebugCommand", "Toggle debug mode"),
+    "exit": CommandSpec("exit", "ExitCommand", "Exit TunaCode"),
+    "model": CommandSpec("model", "ModelCommand", "Change or show current model"),
+    "resume": CommandSpec("resume", "ResumeCommand", "Resume a previous session"),
+    "skills": CommandSpec("skills", "SkillsCommand", "Browse, search, and load session skills"),
+    "theme": CommandSpec("theme", "ThemeCommand", "Change the active theme"),
+    "thoughts": CommandSpec(
+        "thoughts",
+        "ThoughtsCommand",
+        "Toggle streaming of agent thought text",
+    ),
+    "update": CommandSpec("update", "UpdateCommand", "Update tunacode to latest version"),
+}
+
+COMMAND_DESCRIPTIONS: dict[str, str] = {
+    name: spec.description for name, spec in _COMMAND_SPECS.items()
+}
+
+
+class LazyCommandRegistry(Mapping[str, "Command"]):
+    """Instantiate command handlers only when they are first used."""
+
+    def __init__(self, specs: Mapping[str, CommandSpec]) -> None:
+        self._specs = dict(specs)
+        self._instances: dict[str, Command] = {}
+
+    def __getitem__(self, name: str) -> Command:
+        if name not in self._specs:
+            raise KeyError(name)
+
+        command = self._instances.get(name)
+        if command is not None:
+            return command
+
+        spec = self._specs[name]
+        module = import_module(f"tunacode.ui.commands.{spec.module_name}")
+        command_class = getattr(module, spec.class_name)
+        command = command_class()
+        self._instances[name] = command
+        return command
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._specs)
+
+    def __len__(self) -> int:
+        return len(self._specs)
+
+
+COMMANDS = LazyCommandRegistry(_COMMAND_SPECS)

--- a/src/tunacode/ui/commands/__init__.py
+++ b/src/tunacode/ui/commands/__init__.py
@@ -4,38 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tunacode.ui.commands.base import Command
-from tunacode.ui.commands.cancel import CancelCommand
-from tunacode.ui.commands.clear import ClearCommand
-from tunacode.ui.commands.compact import CompactCommand
-from tunacode.ui.commands.debug import DebugCommand
-from tunacode.ui.commands.exit import ExitCommand
-from tunacode.ui.commands.help import HelpCommand
-from tunacode.ui.commands.model import ModelCommand
-from tunacode.ui.commands.resume import ResumeCommand
-from tunacode.ui.commands.skills import SkillsCommand
-from tunacode.ui.commands.theme import ThemeCommand
-from tunacode.ui.commands.thoughts import ThoughtsCommand
-from tunacode.ui.commands.update import UpdateCommand
+from tunacode.ui.command_registry import COMMANDS
 
 if TYPE_CHECKING:
     from tunacode.ui.app import TextualReplApp
-
-
-COMMANDS: dict[str, Command] = {
-    "help": HelpCommand(),
-    "cancel": CancelCommand(),
-    "clear": ClearCommand(),
-    "compact": CompactCommand(),
-    "debug": DebugCommand(),
-    "exit": ExitCommand(),
-    "model": ModelCommand(),
-    "resume": ResumeCommand(),
-    "skills": SkillsCommand(),
-    "theme": ThemeCommand(),
-    "thoughts": ThoughtsCommand(),
-    "update": UpdateCommand(),
-}
 
 
 async def handle_command(app: TextualReplApp, text: str) -> bool:
@@ -56,9 +28,9 @@ async def handle_command(app: TextualReplApp, text: str) -> bool:
         if cmd_name in COMMANDS:
             await COMMANDS[cmd_name].execute(app, cmd_args)
             return True
-        else:
-            app.notify(f"Unknown command: /{cmd_name}", severity="warning")
-            return True
+
+        app.notify(f"Unknown command: /{cmd_name}", severity="warning")
+        return True
 
     if text.lower() == "exit":
         app.exit()

--- a/src/tunacode/ui/commands/help.py
+++ b/src/tunacode/ui/commands/help.py
@@ -20,14 +20,14 @@ class HelpCommand(Command):
     async def execute(self, app: TextualReplApp, args: str) -> None:
         from rich.table import Table
 
-        from tunacode.ui.commands import COMMANDS
+        from tunacode.ui.command_registry import COMMAND_DESCRIPTIONS
 
         table = Table(title="Commands", show_header=True)
         table.add_column("Command", style=STYLE_PRIMARY)
         table.add_column("Description")
 
-        for name, cmd in COMMANDS.items():
-            table.add_row(f"/{name}", cmd.description)
+        for name, description in COMMAND_DESCRIPTIONS.items():
+            table.add_row(f"/{name}", description)
 
         table.add_row("!<cmd>", "Run shell command")
         table.add_row("exit", "Exit TunaCode (legacy bare command)")

--- a/src/tunacode/ui/renderers/__init__.py
+++ b/src/tunacode/ui/renderers/__init__.py
@@ -1,18 +1,30 @@
 """Rich content renderers for Textual TUI."""
 
-from .errors import render_exception, render_tool_error, render_user_abort  # noqa: F401
-from .panels import (  # noqa: F401
-    ErrorDisplayData,
-    RichPanelRenderer,
-    SearchResultData,
-    ToolDisplayData,
-    error_panel,
-    search_panel,
-    tool_panel,
-    tool_panel_smart,
-)
-from .search import (  # noqa: F401
-    CodeSearchResult,
-    FileSearchResult,
-    SearchDisplayRenderer,
-)
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_RENDERER_EXPORTS = {
+    "render_exception": ".errors",
+    "render_tool_error": ".errors",
+    "render_user_abort": ".errors",
+    "ErrorDisplayData": ".panels",
+    "RichPanelRenderer": ".panels",
+    "SearchResultData": ".panels",
+    "ToolDisplayData": ".panels",
+    "error_panel": ".panels",
+    "search_panel": ".panels",
+    "tool_panel": ".panels",
+    "tool_panel_smart": ".panels",
+    "CodeSearchResult": ".search",
+    "FileSearchResult": ".search",
+    "SearchDisplayRenderer": ".search",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _RENDERER_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_name, __name__), name)

--- a/src/tunacode/ui/repl_support.py
+++ b/src/tunacode/ui/repl_support.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from rich.console import Console
 from rich.text import Text
 
-from tunacode.core.session import StateManager
 from tunacode.core.ui_api.constants import MAX_CALLBACK_CONTENT
 from tunacode.core.ui_api.shared_types import (
     StreamResultProtocol,
@@ -26,6 +25,9 @@ from tunacode.core.ui_api.shared_types import (
 )
 
 from tunacode.ui.widgets import ToolResultDisplay
+
+if TYPE_CHECKING:
+    from tunacode.core.session import StateManager
 
 COLLAPSE_THRESHOLD: int = 10
 

--- a/src/tunacode/ui/shell_runner.py
+++ b/src/tunacode/ui/shell_runner.py
@@ -15,8 +15,6 @@ from rich.console import RenderableType
 from rich.text import Text
 from textual.notifications import SeverityLevel
 
-from tunacode.ui.renderers.tools.bash import render_bash
-
 SHELL_COMMAND_TIMEOUT_SECONDS: float = 120.0
 SHELL_COMMAND_CANCEL_GRACE_SECONDS: float = 0.5
 SHELL_COMMAND_USAGE_TEXT = "Usage: !<command>"
@@ -143,6 +141,8 @@ class ShellRunner:
         max_line_width: int,
     ) -> RenderableType:
         """Format shell output as 4-zone NeXTSTEP panel via BashRenderer."""
+        from tunacode.ui.renderers.tools.bash import render_bash
+
         stdout_text = stdout if stdout else SHELL_OUTPUT_EMPTY
         stderr_text = stderr if stderr else SHELL_STDERR_EMPTY
 

--- a/src/tunacode/ui/widgets/__init__.py
+++ b/src/tunacode/ui/widgets/__init__.py
@@ -1,13 +1,26 @@
 """Textual widgets for TunaCode REPL."""
 
-from .chat import ChatContainer, PanelMeta  # noqa: F401
-from .command_autocomplete import CommandAutoComplete  # noqa: F401
-from .editor import Editor  # noqa: F401
-from .file_autocomplete import FileAutoComplete  # noqa: F401
-from .messages import (  # noqa: F401
-    EditorCompletionsAvailable,
-    EditorSubmitRequested,
-    ToolResultDisplay,
-)
-from .resource_bar import ResourceBar  # noqa: F401
-from .skills_autocomplete import SkillsAutoComplete  # noqa: F401
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_WIDGET_EXPORTS = {
+    "ChatContainer": ".chat",
+    "PanelMeta": ".chat",
+    "CommandAutoComplete": ".command_autocomplete",
+    "Editor": ".editor",
+    "FileAutoComplete": ".file_autocomplete",
+    "EditorCompletionsAvailable": ".messages",
+    "EditorSubmitRequested": ".messages",
+    "ToolResultDisplay": ".messages",
+    "ResourceBar": ".resource_bar",
+    "SkillsAutoComplete": ".skills_autocomplete",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _WIDGET_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_name, __name__), name)

--- a/src/tunacode/ui/widgets/command_autocomplete.py
+++ b/src/tunacode/ui/widgets/command_autocomplete.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 from textual.widgets import Input
 from textual_autocomplete import AutoComplete, DropdownItem, TargetState
 
-from tunacode.ui.commands import COMMANDS
+from tunacode.ui.command_registry import COMMAND_DESCRIPTIONS
 
 COMMAND_PREFIX = "/"
 COMMAND_ARGUMENT_SEPARATOR = " "
 COMMAND_DESCRIPTION_SEPARATOR = " - "
 
 # Pre-compute sorted command items at module load.
-_COMMAND_ITEMS: list[tuple[str, str]] = sorted(
-    [(name, cmd.description) for name, cmd in COMMANDS.items()]
-)
+_COMMAND_ITEMS: list[tuple[str, str]] = sorted(COMMAND_DESCRIPTIONS.items())
 
 
 def _get_command_search_prefix(text: str, cursor_position: int) -> str | None:
@@ -34,7 +32,7 @@ def _is_exact_command_match(command_prefix: str) -> bool:
     if not command_prefix:
         return False
 
-    return command_prefix.lower() in COMMANDS
+    return command_prefix.lower() in COMMAND_DESCRIPTIONS
 
 
 class CommandAutoComplete(AutoComplete):

--- a/src/tunacode/ui/widgets/file_autocomplete.py
+++ b/src/tunacode/ui/widgets/file_autocomplete.py
@@ -2,18 +2,30 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from textual.widgets import Input
 from textual_autocomplete import AutoComplete, DropdownItem, TargetState
 
-from tunacode.core.ui_api.file_filter import FileFilter
+if TYPE_CHECKING:
+    from tunacode.core.ui_api.file_filter import FileFilter
 
 
 class FileAutoComplete(AutoComplete):
     """Real-time @ file autocomplete dropdown."""
 
     def __init__(self, target: Input) -> None:
-        self._filter = FileFilter()
+        self._filter: FileFilter | None = None
         super().__init__(target)
+
+    def _get_filter(self) -> FileFilter:
+        file_filter = self._filter
+        if file_filter is None:
+            from tunacode.core.ui_api.file_filter import FileFilter
+
+            file_filter = FileFilter()
+            self._filter = file_filter
+        return file_filter
 
     def get_search_string(self, target_state: TargetState) -> str:
         """Extract ONLY the part after @ symbol."""
@@ -33,7 +45,7 @@ class FileAutoComplete(AutoComplete):
         at_pos = target_state.text.rfind("@", 0, target_state.cursor_position)
         if at_pos == -1:
             return []
-        candidates = self._filter.complete(search)
+        candidates = self._get_filter().complete(search)
         return [DropdownItem(main=f"@{path}") for path in candidates]
 
     def apply_completion(self, value: str, state: TargetState) -> None:

--- a/src/tunacode/ui/widgets/skills_autocomplete.py
+++ b/src/tunacode/ui/widgets/skills_autocomplete.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from textual.widgets import Input
 from textual_autocomplete import AutoComplete, DropdownItem, DropdownItemHit, TargetState
 
-from tunacode.skills.registry import list_skill_summaries
-from tunacode.skills.search import filter_skill_summaries
+if TYPE_CHECKING:
+    from tunacode.skills.models import SkillSummary
 
 SKILLS_COMMAND_PREFIX = "/skills"
 SEARCH_SUBCOMMAND = "search"
@@ -26,6 +27,18 @@ class SkillsAutoComplete(AutoComplete):
 
     def __init__(self, target: Input) -> None:
         super().__init__(target)
+
+    def _list_skill_summaries(self) -> list[SkillSummary]:
+        from tunacode.skills.registry import list_skill_summaries
+
+        return list_skill_summaries()
+
+    def _filter_skill_summaries(
+        self, skill_summaries: list[SkillSummary], *, query: str
+    ) -> list[SkillSummary]:
+        from tunacode.skills.search import filter_skill_summaries
+
+        return filter_skill_summaries(skill_summaries, query=query)
 
     def get_search_string(self, target_state: TargetState) -> str:
         parsed_state = self._parse_skills_input(target_state)
@@ -101,7 +114,7 @@ class SkillsAutoComplete(AutoComplete):
         if parsed_state.mode == SEARCH_SUBCOMMAND:
             return any(
                 skill_summary.name.casefold() == normalized_search
-                for skill_summary in list_skill_summaries()
+                for skill_summary in self._list_skill_summaries()
             )
 
         if normalized_search in ROOT_SUBCOMMANDS:
@@ -109,7 +122,7 @@ class SkillsAutoComplete(AutoComplete):
 
         return any(
             skill_summary.name.casefold() == normalized_search
-            for skill_summary in list_skill_summaries()
+            for skill_summary in self._list_skill_summaries()
         )
 
     def _subcommand_candidates(self, search: str) -> list[DropdownItem]:
@@ -122,8 +135,8 @@ class SkillsAutoComplete(AutoComplete):
         return [DropdownItem(main=subcommand) for subcommand in matching_subcommands]
 
     def _skill_candidates(self, search: str) -> list[DropdownItem]:
-        skill_summaries = list_skill_summaries()
-        matching_summaries = filter_skill_summaries(skill_summaries, query=search)
+        skill_summaries = self._list_skill_summaries()
+        matching_summaries = self._filter_skill_summaries(skill_summaries, query=search)
         return [DropdownItem(main=skill_summary.name) for skill_summary in matching_summaries]
 
     def get_matches(


### PR DESCRIPTION
## Summary

Reduce TunaCode TUI cold-start overhead by lazifying startup-path imports and deferring expensive work until the UI actually needs it.

This PR is focused on the TUI boot path rather than general CLI startup.

## What changed

### Trim `StateManager` startup cost
- defer `tinyagent` message imports in `core/session/state.py`
- defer compaction imports until deserialization actually happens
- skip message-type loading entirely when saving an empty session
- lazify `core/types` exports and default factories so TUI startup doesn't eagerly import heavier runtime structures

### Keep TUI package imports thin
- make `tunacode.ui`, `tunacode.ui.widgets`, and `tunacode.ui.renderers` lazily resolve exports
- avoid eagerly loading widgets and renderers that are not needed on initial boot

### Lazify command/autocomplete startup work
- replace eager command instantiation with a lazy command registry
- make `/help` and slash-command autocomplete use lightweight command metadata
- defer file-filter and skills registry/search loading until autocomplete is actually used

### Defer optional UI helpers until used
- lazy-create `ShellRunner`
- defer clipboard helper import until copy action is triggered
- defer bash renderer import until shell output is rendered
- avoid token-estimation work for empty conversations
- avoid refreshing the hidden context panel during initial resource-bar updates

## Benchmarks

Measured locally in a fresh interpreter.

### `StateManager` import path
- before: ~0.462s
- after: ~0.138s

### TUI boot micro-benchmark
Benchmark:
- create `StateManager()`
- create `TextualReplApp(...)`
- run a headless `app.run_test(...)`

Results:
- before: ~0.476s total
- after: ~0.244s total

Breakdown after:
- `StateManager()` creation: ~0.020s
- `TextualReplApp(...)` init: ~0.010s
- Textual run/mount/shutdown path: ~0.215s

### `tunacode.ui.app` import
- before: ~0.40s
- after: ~0.38s

The biggest win here comes from reducing startup-time work around the TUI boot path, especially `StateManager` and eager ancillary imports, rather than from `ui.app` import time alone.

## Validation

- `uv run ruff check .`
- `uv run pytest -q`

Result:
- `797 passed, 9 skipped`

## Notes

The main remaining cold-start cost is now largely inside Textual / Rich framework startup and CSS/layout initialization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## State Management Changes

**Message Serialization & Validation:**
- Messages now undergo stricter type validation via a new `_agent_message_types()` helper that centralizes valid tinyagent message types (UserMessage, AssistantMessage, ToolResultMessage, CustomAgentMessage).
- Early-return optimization in `_serialize_messages()` skips processing for empty message lists.
- Message serialization explicitly casts to `Any` before `model_dump()` with defensive type checking that raises `TypeError` if the result is not a dict.

**Deserialization with Enhanced Error Context:**
- `_deserialize_message()` now imports message types locally and validates the role field explicitly, catching `ValidationError` and rethrowing as `TypeError` with contextual information (message index and role) to aid debugging.
- `_deserialize_compaction()` defers CompactionRecord import until deserialization is invoked.

**Type Safety via Runtime-Aware Type Hints:**
- Introduced conditional type alias `MessageHistory` that resolves to `list[AgentMessage]` under `TYPE_CHECKING` but `list[Any]` at runtime. This avoids circular import overhead during startup while maintaining type-checker visibility.
- Tool call registry and usage metrics now instantiate via factory functions (`_build_tool_call_registry()`, `_build_usage_metrics()`) instead of direct constructors, deferring expensive initialization and enabling lazy import of ToolCallRegistry and UsageMetrics.

## Exception Handling Improvements

- `ValidationError` from pydantic deserialization is now caught and converted to `TypeError` with enriched error messages that include array index and message role for traceability.
- Comprehensive `TypeError` coverage for invalid message types, missing/empty role fields, and non-dict serialization results, all with clear contextual error messages.
- Type validation failures now report the actual message index, improving root-cause identification in large conversation histories.

## Type Safety & Import Strategy

- `TYPE_CHECKING` guards added for tinyagent agent types and compaction records, eliminating runtime imports of these heavier dependencies during startup.
- Factory functions use local imports to avoid circular dependencies and defer heavy class instantiation until needed.
- No type safety regressions: runtime type hints remain properly typed under `TYPE_CHECKING` for static analysis while avoiding eager imports at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->