### PR TITLE
Clean up headless tinyagent serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "typer>=0.15.0",
     "click>=8.1.0,<8.2.0",
     "prompt_toolkit>=3.0.52,<4.0.0",
-    "tiny-agent-os>=1.2.7",
+    "tiny-agent-os>=1.2.9",
     "pygments>=2.19.2,<3.0.0",
     "rich>=14.2.0,<15.0.0",
     "defusedxml",

--- a/src/tunacode/ui/main.py
+++ b/src/tunacode/ui/main.py
@@ -6,12 +6,7 @@ import os
 import sys
 
 import typer
-from tinyagent.agent_types import (
-    AssistantMessage,
-    CustomAgentMessage,
-    ToolResultMessage,
-    UserMessage,
-)
+from tinyagent.agent_types import dump_model_dumpable
 
 from tunacode.core import ConfigurationError, UserAbortError
 from tunacode.core.session import StateManager
@@ -175,7 +170,10 @@ def _build_trajectory_json(sm: StateManager) -> str:
     usage = sm.session.usage
     tool_records = runtime.tool_registry.to_legacy_records()
     trajectory = {
-        "messages": [_serialize_message(msg) for msg in conversation.messages],
+        "messages": [
+            dump_model_dumpable(message, where=f"headless trajectory message[{index}]")
+            for index, message in enumerate(conversation.messages)
+        ],
         "tool_calls": tool_records,
         "usage": usage.session_total_usage.to_dict(),
         "success": True,
@@ -260,22 +258,6 @@ def run_headless(
 
     exit_code = asyncio.run(async_run())
     raise typer.Exit(code=exit_code)
-
-
-def _serialize_message(msg: object) -> dict[str, object]:
-    """Serialize an in-memory tinyagent message model to JSON-compatible dict."""
-
-    if not isinstance(msg, UserMessage | AssistantMessage | ToolResultMessage | CustomAgentMessage):
-        raise TypeError(f"Expected tinyagent message model, got {type(msg).__name__}")
-
-    serialized_message = msg.model_dump(exclude_none=True)
-    if not isinstance(serialized_message, dict):
-        raise TypeError(
-            "tinyagent message model_dump(exclude_none=True) must return dict; "
-            f"got {type(serialized_message).__name__}"
-        )
-
-    return serialized_message
 
 
 if __name__ == "__main__":

--- a/tests/system/cli/test_startup.py
+++ b/tests/system/cli/test_startup.py
@@ -6,6 +6,7 @@ These tests verify that both execution modes initialize correctly:
 3. Mock tests for headless response handling
 """
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -93,6 +94,81 @@ class TestHeadlessModeStartup:
         )
         assert result.returncode == 0
         assert "TunaCode" in result.stdout
+
+    def test_headless_output_json_serializes_tinyagent_messages(self) -> None:
+        """Verify --output-json serializes the in-memory tinyagent message models."""
+        from tunacode.core.session import StateManager
+
+        from tunacode.ui.main import app
+
+        runner = CliRunner()
+        isolated_state_manager = StateManager()
+
+        async def _mock_process_request(*, state_manager: StateManager, **_: object) -> MagicMock:
+            state_manager.session.conversation.messages = [
+                UserMessage(content=[TextContent(text="say gm")]),
+                AssistantMessage(content=[TextContent(text="gm!")]),
+            ]
+            state_manager.session.runtime.tool_registry.register(
+                "call_1",
+                "bash",
+                {"cmd": "pwd"},
+            )
+            usage = state_manager.session.usage.session_total_usage
+            usage.input = 11
+            usage.output = 7
+            usage.total_tokens = 18
+            usage.cost.input = 0.11
+            usage.cost.output = 0.07
+            usage.cost.total = 0.18
+
+            mock_agent_run = MagicMock()
+            mock_agent_run.result = "ignored in JSON mode"
+            return mock_agent_run
+
+        with (
+            patch("tunacode.ui.main.state_manager", isolated_state_manager),
+            patch(
+                "tunacode.core.agents.main.process_request",
+                new_callable=AsyncMock,
+                side_effect=_mock_process_request,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["run", "say gm", "--auto-approve", "--output-json", "--timeout", "30"],
+            )
+
+        assert result.exit_code == 0, f"stderr: {result.output}"
+        payload = json.loads(result.output)
+
+        assert payload["success"] is True
+        assert payload["messages"] == [
+            {"role": "user", "content": [{"type": "text", "text": "say gm"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "gm!"}]},
+        ]
+        assert payload["tool_calls"] == [
+            {
+                "tool": "bash",
+                "args": {"cmd": "pwd"},
+                "timestamp": None,
+                "tool_call_id": "call_1",
+            }
+        ]
+        assert payload["usage"] == {
+            "input": 11,
+            "output": 7,
+            "cache_read": 0,
+            "cache_write": 0,
+            "total_tokens": 18,
+            "cost": {
+                "input": 0.11,
+                "output": 0.07,
+                "cache_read": 0.0,
+                "cache_write": 0.0,
+                "total": 0.18,
+            },
+        }
 
 
 class TestTUIInitialization:

--- a/uv.lock
+++ b/uv.lock
@@ -2038,15 +2038,15 @@ wheels = [
 
 [[package]]
 name = "tiny-agent-os"
-version = "1.2.7"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/a3/33b22d291d6306acc04fe46bab13444839d93909511a3f30e5d30b511095/tiny_agent_os-1.2.7.tar.gz", hash = "sha256:dbe2e47660200e745f64a741855a05987c483dcaa7af50942f8eb712a0e8eae6", size = 212291, upload-time = "2026-03-04T20:10:34.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/5b/3126b8dfa82884b71f51554547d70229cf06ce341fe9d1f62bf89302199a/tiny_agent_os-1.2.9.tar.gz", hash = "sha256:c40311d4bba7695a5789d385853c2704553259132f7f4299e03cf20d580ed68f", size = 41403, upload-time = "2026-03-16T19:03:25.759Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/0f/092855203861b5c7ae603648b116658e33ef3a35f6e9c45f06eb8712360c/tiny_agent_os-1.2.7-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8810303531f65aa7ced3315fc215b344be61b87cc9c1f3f73e38daa24703b485", size = 4275890, upload-time = "2026-03-04T20:10:32.524Z" },
+    { url = "https://files.pythonhosted.org/packages/93/46/74f6ad7a828ec638859f5f730699fce8902a54eb5c6b810b0b56911ba536/tiny_agent_os-1.2.9-py3-none-any.whl", hash = "sha256:18d14ded4b3966ec6820cfa43298c1c4ce204bdf51d0bbe523b57ff48f6c3e39", size = 30739, upload-time = "2026-03-16T19:03:24.274Z" },
 ]
 
 [[package]]
@@ -2210,7 +2210,7 @@ requires-dist = [
     { name = "textual", specifier = ">=4.0.0,<5.0.0" },
     { name = "textual-autocomplete", specifier = ">=4.0.6" },
     { name = "textual-dev", marker = "extra == 'dev'" },
-    { name = "tiny-agent-os", specifier = ">=1.2.7" },
+    { name = "tiny-agent-os", specifier = ">=1.2.9" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "typer", specifier = ">=0.15.0" },
     { name = "unimport", marker = "extra == 'dev'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- bump `tiny-agent-os` to `1.2.9` so TunaCode consumes a `py.typed` tinyagent release
- remove the redundant local headless message serializer in `src/tunacode/ui/main.py`
- add a mocked `run --output-json` regression that asserts serialized messages, tool calls, usage, and success

## Validation
- `uv run python - <<'PY'
import importlib.metadata as md
import importlib.resources as ir
print(md.version("tiny-agent-os"))
print(ir.files("tinyagent").joinpath("py.typed").is_file())
PY`
- `uv run mypy src/tunacode/ui/main.py`
- `uv run pytest tests/system/cli/test_startup.py`
- `uv run python scripts/check_agents_freshness.py`

## Known issue
- The repository pre-commit `mypy` hook now surfaces 341 pre-existing `Any`-related errors in `src/tunacode/core/agents/*` after the `tiny-agent-os` package became typed. That broader cleanup was explicitly out of scope for this task, so this PR keeps the narrow serializer/test change set and leaves those agent-module fixes for follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## State Management Changes

The PR refactors message serialization in the headless trajectory output. The session's conversation messages are now serialized using `dump_model_dumpable()` from tinyagent (added in the new test as a regression check), which extracts in-memory message objects into JSON-compatible dicts. A new test method `test_headless_output_json_serializes_tinyagent_messages` validates that the serialized trajectory includes all session state components: messages (user/assistant), tool calls, and usage statistics from `session.runtime` and `session.usage`.

## Exception Handling Paths

The removed `_serialize_message()` function previously included explicit exception handling:
- Type validation (`isinstance(msg, UserMessage | AssistantMessage | ToolResultMessage | CustomAgentMessage)`) with `TypeError` on mismatch
- Return type validation on `model_dump(exclude_none=True)` output

The new implementation delegates exception handling to `dump_model_dumpable()` from tinyagent, with context passed via the `where` parameter (`where=f"headless trajectory message[{index}]"`). The trajectory building function `_build_trajectory_json()` no longer has try-catch around serialization—validation is pushed upstream to the tinyagent library, which should raise errors with diagnostic context if serialization fails.

## Type Safety Improvements

tiny-agent-os 1.2.9 now includes `py.typed`, providing full type information for tinyagent's message models. The PR replaces the manual union type checking (`UserMessage | AssistantMessage | ToolResultMessage | CustomAgentMessage`) with a library-provided `dump_model_dumpable()` function that is inherently type-aware. Import changes: specific message types are no longer imported; only `dump_model_dumpable` is imported from `tinyagent.agent_types`.

## Dead Code Removed

The `_serialize_message()` helper function (18 lines) is removed entirely. This function was a local reimplementation of message serialization logic that is now redundant given tinyagent's typed `dump_model_dumpable()` export. The test suite replaces the implicit validation with an explicit regression test that mocks session state and asserts the JSON output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->