### PR TITLE
Simplify tinyagent helper utilities

### DIFF
--- a/src/tunacode/core/agents/helpers.py
+++ b/src/tunacode/core/agents/helpers.py
@@ -42,9 +42,7 @@ class _TinyAgentStreamState:
 
 
 def coerce_error_text(value: object) -> str:
-    if isinstance(value, str):
-        return value
-    return ""
+    return value if isinstance(value, str) else ""
 
 
 def is_context_overflow_error(error_text: str) -> bool:
@@ -64,16 +62,12 @@ def parse_canonical_usage(raw_usage: object) -> UsageMetrics:
         raise RuntimeError(f"Assistant message usage contract violation: {exc}") from exc
 
 
-def is_tinyagent_message(value: object) -> bool:
-    return isinstance(value, _AGENT_MESSAGE_TYPES)
-
-
 def coerce_tinyagent_history(messages: Iterable[object]) -> list[AgentMessage]:
     message_list = list(messages)
     if not message_list:
         return []
 
-    if all(is_tinyagent_message(message) for message in message_list):
+    if all(isinstance(message, _AGENT_MESSAGE_TYPES) for message in message_list):
         return [cast(AgentMessage, message) for message in message_list]
 
     raise TypeError(
@@ -86,11 +80,9 @@ def extract_tool_result_text(result: AgentToolResult | None) -> str | None:
     if result is None:
         return None
 
-    parts: list[str] = []
-    for item in result.content:
-        if not isinstance(item, TextContent):
-            continue
-        if isinstance(item.text, str):
-            parts.append(item.text)
-
-    return "".join(parts) if parts else None
+    text_parts = [
+        item.text
+        for item in result.content
+        if isinstance(item, TextContent) and isinstance(item.text, str)
+    ]
+    return "".join(text_parts) if text_parts else None


### PR DESCRIPTION
### Motivation
- Reduce surface area and improve readability in tinyagent helper utilities by collapsing trivial indirection and simplifying small iterative logic while preserving existing behavior.

### Description
- Simplified `coerce_error_text` to a single expression `return value if isinstance(value, str) else ""` to remove a trivial branch.
- Removed single-use helper `is_tinyagent_message` and inlined its `isinstance(..., _AGENT_MESSAGE_TYPES)` check inside `coerce_tinyagent_history` to reduce indirection.
- Rewrote `extract_tool_result_text` using a focused list-comprehension that collects `item.text` when `item` is `TextContent` and `item.text` is `str`, preserving the original `None` vs string return contract.

### Testing
- Ran `uv run pytest tests/core/agents -q`, which failed because the test path does not exist (no tests collected for that path).
- Ran `uv run pytest tests/unit/core/test_provider_error_surfacing.py tests/unit/core/test_context_overflow_detection.py tests/unit/core/test_openrouter_usage_metrics.py -q`, which collected 14 tests and all passed (`14 passed` in ~15s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba8ec7b2fc8325b602bcafea7239a8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Type Safety and Message Validation

**Strengthened type validation in message handling:** The `coerce_tinyagent_history` function now uses direct `isinstance(message, _AGENT_MESSAGE_TYPES)` checks instead of delegating to a removed helper. The validation explicitly checks all four expected message types (`UserMessage`, `AssistantMessage`, `ToolResultMessage`, `CustomAgentMessage`) before casting, maintaining the same type safety contract while making the validation logic more transparent.

## Dead Code Removal

**Eliminated trivial indirection:** Removed `is_tinyagent_message(value: object) -> bool`, a single-use helper that only wrapped an `isinstance` check. This function had no call sites elsewhere in the codebase. Its call site in `coerce_tinyagent_history` now directly uses the type tuple `_AGENT_MESSAGE_TYPES`, reducing abstraction layers without sacrificing clarity.

## Exception Handling Paths

**Preserved error semantics:** Exception handling remains unchanged:
- `parse_canonical_usage` continues to raise `RuntimeError` with contextual error messages (missing usage payload, contract violations)
- `coerce_tinyagent_history` continues to raise `TypeError` with the same message content when non-tinyagent messages are detected
- `coerce_error_text` and `extract_tool_result_text` error contracts remain intact (returning `""` and `None` respectively for invalid inputs)

## Tool Result Text Extraction

**Refactored to list comprehension:** `extract_tool_result_text` now uses a list comprehension that filters `result.content` items by both type (`isinstance(item, TextContent)`) and string validation (`isinstance(item.text, str)`), then joins non-empty results. This preserves the original None vs. string return contract—returns `None` if no text parts are collected, otherwise returns the joined string.

## State Management

No changes to the `_TinyAgentStreamState` dataclass or its fields (`runtime`, `tool_start_times`, `active_tool_call_ids`, `batch_tool_call_ids`, `last_assistant_message`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->