### PR TITLE
[codex] perf: cache conversation total tokens and improve request debug flow

### DIFF
--- a/.artifacts/research/2026-04-01_23-32-20_session-save-tail-and-message-boundary.md
+++ b/.artifacts/research/2026-04-01_23-32-20_session-save-tail-and-message-boundary.md
@@ -1,0 +1,78 @@
+---
+title: "session save tail and message boundary map"
+link: "session-save-tail-and-message-boundary-map"
+type: research
+ontological_relations:
+  - relates_to: [[docs/modules/core/core.md]]
+  - relates_to: [[docs/modules/ui/ui.md]]
+  - relates_to: [[docs/modules/utils/utils.md]]
+  - relates_to: [[docs/architecture/patterns/agent-message-serialization.md]]
+tags: [research, session, persistence, ui, messaging]
+uuid: "a4b7f6f1-1a94-4cfa-b495-849a82929b71"
+created_at: "2026-04-01T23:32:20.690411-05:00"
+---
+
+## Structure
+- `src/tunacode/core/session/` contains the persisted session state manager; `state.py:162-342` defines the session file path, message serialization/deserialization helpers, and `save_session()`.
+- `src/tunacode/core/types/state_structures.py:38-76` defines the in-memory conversation/runtime/usage dataclasses used by `SessionState`.
+- `src/tunacode/utils/messaging/` contains the message adapter and heuristic token counter; `adapter.py:315-337` is the tinyagent→canonical conversion path and `token_counter.py:35-66` is the per-message/per-history token scan.
+- `src/tunacode/core/ui_api/messaging.py:29-36` is the UI-facing facade that forwards token estimation into `tunacode.utils.messaging`.
+- `src/tunacode/ui/app.py:405-445` finalizes a request, renders the response panel, updates the resource bar, and then auto-saves the session.
+- `src/tunacode/ui/renderers/agent_response.py:112-159` renders only the finalized response content and throughput text.
+- `src/tunacode/core/compaction/controller.py:148-149,324-327` also reuses the same token estimator for threshold checks and compaction record updates.
+- `docs/architecture/patterns/agent-message-serialization.md:1-152` documents the message-shape boundaries between tinyagent models, canonical dataclasses, and dict payloads.
+
+## Key Files
+- `AGENTS.md:110-115` records the repository rule: use tinyagent models directly in memory and keep dict payloads at real boundaries.
+- `src/tunacode/core/types/state_structures.py:39-45` defines `ConversationState.messages` as `list[AgentMessage]` with a separate `total_tokens` field.
+- `src/tunacode/core/session/state.py:169-173` serializes every in-memory tinyagent message with `message.model_dump(exclude_none=True)`.
+- `src/tunacode/core/session/state.py:318-342` rebuilds the full `session_data` dict and writes it with `json.dump(..., indent=2)` inside `save_session()`.
+- `src/tunacode/ui/app.py:430-445` awaits `self.state_manager.save_session()` after each completed request and logs `save_session_ms` plus `message_count`.
+- `src/tunacode/ui/lifecycle.py:35-36` also saves the session during app unmount.
+- `src/tunacode/ui/app.py:663-698` computes estimated conversation tokens by calling `_estimate_conversation_tokens(conversation.messages)` and forwarding to `core.ui_api.messaging.estimate_messages_tokens()`.
+- `src/tunacode/ui/app.py:733-759` recomputes estimated tokens during `_update_resource_bar()` and, when the context panel is visible, calls `_refresh_context_panel()` which also estimates tokens at `src/tunacode/ui/app.py:659-676`.
+- `src/tunacode/utils/messaging/token_counter.py:3-11` states that the token counter supports typed tinyagent messages in memory and JSON dicts at persistence boundaries.
+- `src/tunacode/utils/messaging/token_counter.py:35-66` converts non-canonical messages through `to_canonical()` and loops the full message sequence to sum estimated tokens.
+- `src/tunacode/utils/messaging/adapter.py:315-337` converts an `AgentMessage` or dict payload into `CanonicalMessage`, using `message.model_dump(exclude_none=True)` for non-dict messages at `adapter.py:308-312`.
+- `src/tunacode/core/compaction/controller.py:148-149` estimates total history tokens in `should_compact()` before each compaction decision.
+- `src/tunacode/core/compaction/controller.py:324-327` re-estimates `tokens_before` and `retained_tokens` when writing a new `CompactionRecord`.
+- `src/tunacode/core/agents/main.py:320-322` uses `estimate_messages_tokens(conversation.messages)` when raising `ContextOverflowError`.
+- `src/tunacode/ui/renderers/agent_response.py:112-145` formats the final response panel from the latest response content, output-token count, and duration only.
+
+## Patterns Found
+- In-memory conversation history is typed as tinyagent `AgentMessage` objects in `ConversationState.messages` (`src/tunacode/core/types/state_structures.py:42`).
+- Session persistence converts that typed history to JSON dictionaries at save time in `StateManager._serialize_messages()` (`src/tunacode/core/session/state.py:169-173`) and converts dicts back to tinyagent models in `_deserialize_messages()` (`src/tunacode/core/session/state.py:206-219`).
+- `save_session()` constructs the full persistence payload before the threaded file write begins; the `session_data` dict is assembled at `src/tunacode/core/session/state.py:325-338`, and the thread handoff occurs at `src/tunacode/core/session/state.py:341-342`.
+- The token estimator is a full-history sum: `estimate_messages_tokens()` iterates every message (`src/tunacode/utils/messaging/token_counter.py:60-66`), and `estimate_message_tokens()` canonicalizes each non-canonical message first (`src/tunacode/utils/messaging/token_counter.py:42`).
+- The canonicalization step for tinyagent messages uses `model_dump(exclude_none=True)` via `_coerce_agent_message_dict()` (`src/tunacode/utils/messaging/adapter.py:308-312`).
+- UI token display uses estimator results rather than `ConversationState.total_tokens`; repository search `rg -n "conversation\.total_tokens" src/tunacode tests docs` returned no matches, while `ConversationState.total_tokens` is declared at `src/tunacode/core/types/state_structures.py:44` and referenced in a comment at `src/tunacode/ui/commands/clear.py:27`.
+- `_update_resource_bar()` estimates tokens once at `src/tunacode/ui/app.py:739-748`; if the context panel is visible, it then triggers `_refresh_context_panel()` (`src/tunacode/ui/app.py:758-759`), which estimates tokens again at `src/tunacode/ui/app.py:663-676`.
+- The same token-count helper is reused outside the UI in compaction and overflow paths (`src/tunacode/core/compaction/controller.py:148-149,324-327`; `src/tunacode/core/agents/main.py:320-322`).
+- Final response rendering is scoped to one response string and metadata. `render_agent_response()` does not iterate the full conversation; it creates a `Markdown(content)` viewport and optional throughput status (`src/tunacode/ui/renderers/agent_response.py:136-145`).
+- Additional `save_session()` call sites exist in UI lifecycle and commands: `src/tunacode/ui/lifecycle.py:35-36`, `src/tunacode/ui/commands/skills.py:75,88`, `src/tunacode/ui/commands/resume.py:128`, `src/tunacode/ui/commands/clear.py:52`, and `src/tunacode/ui/commands/compact.py:92`.
+
+## Dependencies
+- `src/tunacode/ui/app.py` imports `AgentMessage` from `tinyagent.agent_types` and calls `tunacode.core.ui_api.messaging.estimate_messages_tokens()` from `_estimate_conversation_tokens()` (`src/tunacode/ui/app.py:692-698`).
+- `src/tunacode/core/ui_api/messaging.py:8-12` depends on `tinyagent.agent_types`, `tunacode.types.canonical`, and forwards to `tunacode.utils.messaging`.
+- `src/tunacode/utils/messaging/token_counter.py:19-22` depends on `tinyagent.agent_types`, `tunacode.types.canonical`, and `tunacode.utils.messaging.adapter.to_canonical()`.
+- `src/tunacode/utils/messaging/adapter.py:19-37` depends on tinyagent message types plus canonical message dataclasses from `tunacode.types.canonical`.
+- `src/tunacode/core/session/state.py:22-26` depends on configuration defaults, public types, canonical `UsageMetrics`, and core state structures.
+- `src/tunacode/core/compaction/controller.py` imports `estimate_messages_tokens` from `tunacode.utils.messaging` and writes compaction metadata back through `state_manager.session.compaction`.
+- `src/tunacode/core/agents/main.py:51-76` depends on `estimate_messages_tokens`, compaction controller/types, logging, state protocols, and resume sanitization.
+- `docs/architecture/patterns/agent-message-serialization.md` maps the same boundary in prose: tinyagent models, canonical dataclasses, and dict payloads participate in the current message flow.
+
+## Symbol Index
+- `tunacode.core.session.state.SessionState` — `src/tunacode/core/session/state.py:35`
+- `tunacode.core.session.state.StateManager` — `src/tunacode/core/session/state.py:77`
+- `tunacode.core.session.state.StateManager._serialize_messages()` — `src/tunacode/core/session/state.py:169`
+- `tunacode.core.session.state.StateManager.save_session()` — `src/tunacode/core/session/state.py:318`
+- `tunacode.core.types.state_structures.ConversationState` — `src/tunacode/core/types/state_structures.py:39`
+- `tunacode.core.ui_api.messaging.estimate_messages_tokens()` — `src/tunacode/core/ui_api/messaging.py:29`
+- `tunacode.utils.messaging.token_counter.estimate_message_tokens()` — `src/tunacode/utils/messaging/token_counter.py:35`
+- `tunacode.utils.messaging.token_counter.estimate_messages_tokens()` — `src/tunacode/utils/messaging/token_counter.py:60`
+- `tunacode.utils.messaging.adapter.to_canonical()` — `src/tunacode/utils/messaging/adapter.py:315`
+- `tunacode.utils.messaging.adapter.get_content()` — `src/tunacode/utils/messaging/adapter.py:471`
+- `tunacode.core.agents.main.RequestOrchestrator` — `src/tunacode/core/agents/main.py:134`
+- `tunacode.core.agents.main.RequestOrchestrator._persist_agent_messages()` — `src/tunacode/core/agents/main.py:351`
+- `tunacode.ui.renderers.agent_response.render_agent_response()` — `src/tunacode/ui/renderers/agent_response.py:112`
+- `tunacode.ui.lifecycle.AppLifecycle` — `src/tunacode/ui/lifecycle.py:21`

--- a/.artifacts/research/2026-04-01_tinyagent-boundary.md
+++ b/.artifacts/research/2026-04-01_tinyagent-boundary.md
@@ -1,0 +1,62 @@
+---
+title: "tinyagent boundary map"
+link: "tinyagent-boundary-map"
+type: research
+ontological_relations:
+  - relates_to: [[docs/modules/utils/utils.md]]
+  - relates_to: [[docs/modules/core/core.md]]
+  - relates_to: [[docs/modules/tools/tools.md]]
+tags: [research, tinyagent, boundary]
+uuid: "b8d0d0c6-8b0d-4ff6-8f78-53f14ec7b8f5"
+created_at: "2026-04-01T00:00:00-05:00"
+---
+
+## Structure
+- `src/tunacode/core/types/state_structures.py:38-76` defines the in-memory conversation state as `list[AgentMessage]` and the runtime/session sub-states that carry it.
+- `src/tunacode/core/agents/agent_components/agent_config.py:244-254` builds the active tool list from native tinyagent tools and applies only a concurrency wrapper.
+- `src/tunacode/tools/` contains the native tinyagent tool modules referenced by the agent config; `bash.py:200-206` and `read_file.py:167-173` show the direct `AgentTool` exports.
+- `src/tunacode/core/agents/main.py:104-131` serializes and deserializes tinyagent message models during the abort-cleanup path.
+- `src/tunacode/core/agents/resume/sanitize.py:184-210` parses persisted dict messages for resume, validates them through the adapter, and returns typed resume-message dataclasses.
+- `src/tunacode/utils/messaging/adapter.py:315-463` is the bidirectional translation layer between tinyagent message payloads and TunaCode canonical messages.
+
+## Key Files
+- `src/tunacode/utils/messaging/adapter.py:1-12` documents the boundary explicitly: in-memory runtime uses typed tinyagent models, persisted session JSON stores dicts at the serialization boundary, and canonical dataclasses sit in the middle.
+- `src/tunacode/utils/messaging/adapter.py:315-343` converts tinyagent dicts or `AgentMessage` objects into `CanonicalMessage`.
+- `src/tunacode/utils/messaging/adapter.py:346-463` converts canonical messages back to tinyagent dicts.
+- `src/tunacode/utils/messaging/adapter.py:471-505` provides extraction helpers used by compaction and tool-history code.
+- `src/tunacode/core/agents/main.py:104-131` defines `_serialize_agent_messages()` and `_deserialize_agent_messages()`, which work on tinyagent message models and dict payloads.
+- `src/tunacode/core/agents/main.py:351-379` captures the abort-cleanup boundary: it serializes `session.conversation.messages`, runs resume cleanup, and deserializes back to typed tinyagent messages when cleanup changed the history.
+- `src/tunacode/core/agents/main.py:497-527` converts native tool results into canonical tool-result objects before updating runtime tool state and invoking the UI callback.
+- `src/tunacode/core/agents/agent_components/agent_config.py:208-255` wraps each native tool with a semaphore and returns the resulting `AgentTool` list.
+- `src/tunacode/core/agents/helpers.py:57-144` parses usage payloads, extracts tool-result text, and canonicalizes native `AgentToolResult` values into TunaCode canonical tool results.
+- `src/tunacode/core/agents/resume/sanitize.py:119-210` parses request, assistant, and tool-result content items from persisted dict messages and rejects unsupported roles or content types.
+- `src/tunacode/core/agents/resume/sanitize.py:264-485` serializes the typed resume dataclasses back to tinyagent-style dict messages and mutates the message list during cleanup.
+- `src/tunacode/ui/commands/compact.py:125-129` enforces that `/compact` operates on tinyagent message models only.
+- `src/tunacode/infrastructure/cache/caches/agents.py:16-57` caches tinyagent `Agent` instances keyed by model name with version metadata.
+
+## Patterns Found
+- Native tinyagent message models are the in-memory form in `ConversationState.messages` and in request/stream processing.
+- Dict payloads appear at persistence and resume boundaries, not as the primary in-memory representation.
+- Canonical message dataclasses are used for normalization, extraction, and compaction helpers.
+- Native tinyagent tools are registered directly as `AgentTool` objects with `execute(tool_call_id, args, signal, on_update)` handlers and `AgentToolResult` outputs.
+
+## Dependencies
+- `core/agents/main.py` imports `tinyagent.agent.Agent`, `tinyagent.agent_types.*`, `tunacode.utils.messaging.estimate_messages_tokens`, `canonicalize_tool_result`, and `resume.sanitize`.
+- `core/agents/resume/sanitize.py` imports `adapter.to_canonical()` before its own structural parsing.
+- `core/agents/agent_components/agent_config.py` imports the six active native tool modules directly and hands them to tinyagent.
+- `core/compaction/controller.py:132-176` works on `list[AgentMessage]` and uses `estimate_messages_tokens()` from `tunacode.utils.messaging`.
+- `docs/modules/utils/utils.md:37-71` states the adapter is the translation point between tinyagent dicts and canonical messages.
+- `docs/modules/tools/tools.md:15-18` states the tools layer exposes native tinyagent tool contracts directly.
+- `docs/modules/core/core.md:15-16,124-133` states the core layer runs the agent loop and serializes session messages as tinyagent dicts for persistence.
+
+## Symbol Index
+- `tunacode.utils.messaging.adapter.to_canonical()` at `src/tunacode/utils/messaging/adapter.py:315`
+- `tunacode.utils.messaging.adapter.from_canonical()` at `src/tunacode/utils/messaging/adapter.py:442`
+- `tunacode.utils.messaging.adapter.find_dangling_tool_calls()` at `src/tunacode/utils/messaging/adapter.py:495`
+- `tunacode.core.agents.main._serialize_agent_messages()` at `src/tunacode/core/agents/main.py:104`
+- `tunacode.core.agents.main._deserialize_agent_messages()` at `src/tunacode/core/agents/main.py:111`
+- `tunacode.core.agents.main.RequestOrchestrator` at `src/tunacode/core/agents/main.py:134`
+- `tunacode.core.agents.helpers.canonicalize_tool_result()` at `src/tunacode/core/agents/helpers.py:110`
+- `tunacode.core.agents.resume.sanitize.sanitize_history_for_resume()` at `src/tunacode/core/agents/resume/sanitize.py:434`
+- `tunacode.tools.bash.bash` at `src/tunacode/tools/bash.py:200`
+- `tunacode.tools.read_file.read_file` at `src/tunacode/tools/read_file.py:167`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-03-31
+Last Updated: 2026-04-02
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.

--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -48,7 +48,7 @@ from tunacode.types import (
     ToolStartCallback,
     UsageMetrics,
 )
-from tunacode.utils.messaging import estimate_messages_tokens
+from tunacode.utils.messaging import estimate_message_tokens, estimate_messages_tokens
 
 from tunacode.core.compaction.controller import (
     CompactionStatusCallback,
@@ -316,8 +316,13 @@ class RequestOrchestrator:
 
         if self.notice_callback is not None:
             self.notice_callback(CONTEXT_OVERFLOW_FAILURE_NOTICE)
+        estimated_tokens = conversation.total_tokens
+        if estimated_tokens == 0 and conversation.messages:
+            estimated_tokens = estimate_messages_tokens(conversation.messages)
+            conversation.total_tokens = estimated_tokens
+
         raise ContextOverflowError(
-            estimated_tokens=estimate_messages_tokens(conversation.messages),
+            estimated_tokens=estimated_tokens,
             max_tokens=conversation.max_tokens or DEFAULT_CONTEXT_WINDOW,
             model=self.model,
         )
@@ -352,6 +357,7 @@ class RequestOrchestrator:
         conversation = self.state_manager.session.conversation
         external_messages = list(conversation.messages[baseline_message_count:])
         conversation.messages = [*list(agent.state.messages), *external_messages]
+        conversation.total_tokens = estimate_messages_tokens(conversation.messages)
 
     def _remove_in_flight_tool_registry_entries(self, logger: LogManager) -> None:
         active_stream_state = self._active_stream_state
@@ -377,6 +383,9 @@ class RequestOrchestrator:
         )
         if cleanup_applied:
             session.conversation.messages = _deserialize_agent_messages(serialized_messages)
+            session.conversation.total_tokens = estimate_messages_tokens(
+                session.conversation.messages
+            )
         if cleanup_applied and dangling_tool_call_ids:
             logger.lifecycle(
                 f"Cleaned up {len(dangling_tool_call_ids)} dangling tool call(s) after abort"
@@ -396,13 +405,13 @@ class RequestOrchestrator:
         if latest_assistant_text.strip() == partial_text.strip():
             return
 
-        session.conversation.messages.append(
-            AssistantMessage(
-                content=[TextContent(text=f"[INTERRUPTED]\n\n{partial_text}")],
-                stop_reason="aborted",
-                timestamp=int(time.time() * MILLISECONDS_PER_SECOND),
-            )
+        interrupted_message = AssistantMessage(
+            content=[TextContent(text=f"[INTERRUPTED]\n\n{partial_text}")],
+            stop_reason="aborted",
+            timestamp=int(time.time() * MILLISECONDS_PER_SECOND),
         )
+        session.conversation.messages.append(interrupted_message)
+        session.conversation.total_tokens += estimate_message_tokens(interrupted_message)
 
     async def _handle_stream_turn_end(
         self,

--- a/src/tunacode/core/compaction/controller.py
+++ b/src/tunacode/core/compaction/controller.py
@@ -145,8 +145,17 @@ class CompactionController:
         threshold_tokens = max_tokens - reserve - self.keep_recent_tokens
         effective_threshold = max(0, threshold_tokens)
 
-        estimated_tokens = estimate_messages_tokens(messages)
+        estimated_tokens = self._estimated_tokens(messages)
         return estimated_tokens > effective_threshold
+
+    def _estimated_tokens(self, messages: list[AgentMessage]) -> int:
+        conversation = self._state_manager.session.conversation
+        if messages is conversation.messages:
+            if conversation.total_tokens > 0 or not messages:
+                return conversation.total_tokens
+            conversation.total_tokens = estimate_messages_tokens(messages)
+            return conversation.total_tokens
+        return estimate_messages_tokens(messages)
 
     async def check_and_compact(
         self,
@@ -321,7 +330,7 @@ class CompactionController:
         previous_summary = None if previous_record is None else previous_record.summary
         previous_count = 0 if previous_record is None else previous_record.compaction_count
 
-        tokens_before = estimate_messages_tokens(all_messages)
+        tokens_before = self._estimated_tokens(all_messages)
         retained_tokens = estimate_messages_tokens(retained_messages)
         summary_tokens = estimate_tokens(summary)
         tokens_after = retained_tokens + summary_tokens
@@ -471,7 +480,9 @@ def apply_compaction_messages(
     """Apply compaction output to session conversation with one shared write path."""
 
     applied_messages = list(messages)
-    state_manager.session.conversation.messages = applied_messages
+    conversation = state_manager.session.conversation
+    conversation.messages = applied_messages
+    conversation.total_tokens = estimate_messages_tokens(applied_messages)
     return applied_messages
 
 

--- a/src/tunacode/core/session/state.py
+++ b/src/tunacode/core/session/state.py
@@ -364,28 +364,18 @@ class StateManager:
             data = await asyncio.to_thread(self._read_session_data, session_file)
 
             session_id_value = self._coerce_str_value(data.get("session_id"), session_id)
-            self._session.session_id = session_id_value
             project_id_value = self._coerce_str_value(data.get("project_id"), "")
-            self._session.project_id = project_id_value
             created_at_value = self._coerce_str_value(data.get("created_at"), "")
-            self._session.created_at = created_at_value
             last_modified_value = self._coerce_str_value(data.get("last_modified"), "")
-            self._session.last_modified = last_modified_value
             working_directory_value = self._coerce_str_value(data.get("working_directory"), "")
-            self._session.working_directory = working_directory_value
-            self._session.selected_skill_names = self._deserialize_selected_skill_names(
+            selected_skill_names = self._deserialize_selected_skill_names(
                 data.get("selected_skill_names")
             )
             default_model = DEFAULT_USER_CONFIG["default_model"]
             current_model_value = self._coerce_str_value(data.get("current_model"), default_model)
-            self._session.current_model = current_model_value
             # Update max_tokens based on loaded model's context window
-            self._session.conversation.max_tokens = get_model_context_window(
-                self._session.current_model
-            )
-            self._session.usage.session_total_usage = UsageMetrics.from_dict(
-                data.get("session_total_usage", {})
-            )
+            max_tokens_value = get_model_context_window(current_model_value)
+            session_total_usage = UsageMetrics.from_dict(data.get("session_total_usage", {}))
 
             raw_messages = data.get("messages", [])
             if not isinstance(raw_messages, list):
@@ -397,10 +387,24 @@ class StateManager:
             loaded_messages = self._deserialize_messages(cleaned_messages)
             stored_thoughts = self._deserialize_thoughts(data.get("thoughts"))
 
-            self._session.conversation.thoughts = [*stored_thoughts, *extracted_thoughts]
-            self._session.conversation.messages = loaded_messages
-            self._session.conversation.total_tokens = estimate_messages_tokens(loaded_messages)
-            self._session.compaction = self._deserialize_compaction(data.get("compaction"))
+            conversation_thoughts = [*stored_thoughts, *extracted_thoughts]
+            conversation_total_tokens = estimate_messages_tokens(loaded_messages)
+            session_compaction = self._deserialize_compaction(data.get("compaction"))
+
+            session = self._session
+            session.session_id = session_id_value
+            session.project_id = project_id_value
+            session.created_at = created_at_value
+            session.last_modified = last_modified_value
+            session.working_directory = working_directory_value
+            session.selected_skill_names = selected_skill_names
+            session.current_model = current_model_value
+            session.conversation.max_tokens = max_tokens_value
+            session.usage.session_total_usage = session_total_usage
+            session.conversation.thoughts = conversation_thoughts
+            session.conversation.messages = loaded_messages
+            session.conversation.total_tokens = conversation_total_tokens
+            session.compaction = session_compaction
 
             return True
         except json.JSONDecodeError:

--- a/src/tunacode/core/session/state.py
+++ b/src/tunacode/core/session/state.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from tunacode.configuration.defaults import DEFAULT_USER_CONFIG
 from tunacode.types import InputSessions, ModelName, SessionId, UserConfig
 from tunacode.types.canonical import UsageMetrics
+from tunacode.utils.messaging import estimate_messages_tokens
 
 from tunacode.core.types import ConversationState, RuntimeState, TaskState, UsageState
 
@@ -398,6 +399,7 @@ class StateManager:
 
             self._session.conversation.thoughts = [*stored_thoughts, *extracted_thoughts]
             self._session.conversation.messages = loaded_messages
+            self._session.conversation.total_tokens = estimate_messages_tokens(loaded_messages)
             self._session.compaction = self._deserialize_compaction(data.get("compaction"))
 
             return True

--- a/src/tunacode/ui/app.py
+++ b/src/tunacode/ui/app.py
@@ -357,7 +357,14 @@ class TextualReplApp(App[None]):
                 thread=True,
             )
             self._current_request_task = worker
-            await worker.wait()
+            worker_started_at = time.monotonic()
+            try:
+                await worker.wait()
+            finally:
+                worker_duration_ms = (
+                    time.monotonic() - worker_started_at
+                ) * self.MILLISECONDS_PER_SECOND
+                self._request_debug.note_request_worker_completed(duration_ms=worker_duration_ms)
         except WorkerCancelled:
             self.notify("Cancelled")
         except WorkerFailed as e:
@@ -374,7 +381,13 @@ class TextualReplApp(App[None]):
             content, meta = render_exception(e)
             self.chat_container.write(content, panel_meta=meta)
         finally:
+            post_stream_started_at = time.monotonic()
+
+            final_flush_started_at = time.monotonic()
             await self._flush_request_deltas()
+            final_flush_ms = (
+                time.monotonic() - final_flush_started_at
+            ) * self.MILLISECONDS_PER_SECOND
             self._stop_delta_flush_timer()
             self._request_bridge = None
             self._current_request_task = None
@@ -385,6 +398,9 @@ class TextualReplApp(App[None]):
             self.streaming.reset()
             self._finalize_thinking_state_after_request()
             self._update_compaction_status(False)
+            response_panel_ms = 0.0
+            response_char_count = 0
+            response_panel_started_at = time.monotonic()
             output_text = self._get_latest_response_text()
             if output_text is not None:
                 from tunacode.ui.renderers.agent_response import render_agent_response
@@ -402,9 +418,33 @@ class TextualReplApp(App[None]):
                 self.chat_container.write("")
                 response_widget = self.chat_container.write(content, expand=True, panel_meta=meta)
                 self.chat_container.set_insertion_anchor(response_widget)
+                response_char_count = len(output_text)
+            response_panel_ms = (
+                time.monotonic() - response_panel_started_at
+            ) * self.MILLISECONDS_PER_SECOND
+            resource_bar_started_at = time.monotonic()
             self._update_resource_bar()
+            resource_bar_update_ms = (
+                time.monotonic() - resource_bar_started_at
+            ) * self.MILLISECONDS_PER_SECOND
             # Auto-save session after processing
+            save_session_started_at = time.monotonic()
             await self.state_manager.save_session()
+            save_session_ms = (
+                time.monotonic() - save_session_started_at
+            ) * self.MILLISECONDS_PER_SECOND
+            post_stream_cleanup_ms = (
+                time.monotonic() - post_stream_started_at
+            ) * self.MILLISECONDS_PER_SECOND
+            self._request_debug.note_post_stream_cleanup(
+                final_flush_ms=final_flush_ms,
+                response_panel_ms=response_panel_ms,
+                response_chars=response_char_count,
+                resource_bar_update_ms=resource_bar_update_ms,
+                save_session_ms=save_session_ms,
+                message_count=len(session.conversation.messages),
+                total_cleanup_ms=post_stream_cleanup_ms,
+            )
             total_request_ms = (
                 time.monotonic() - self._request_start_time
             ) * self.MILLISECONDS_PER_SECOND
@@ -654,6 +694,13 @@ class TextualReplApp(App[None]):
             return 0
 
         from tunacode.core.ui_api.messaging import estimate_messages_tokens
+
+        conversation = self.state_manager.session.conversation
+        if messages is conversation.messages:
+            if conversation.total_tokens > 0:
+                return conversation.total_tokens
+            conversation.total_tokens = estimate_messages_tokens(messages)
+            return conversation.total_tokens
 
         return estimate_messages_tokens(messages)
 

--- a/src/tunacode/ui/app.py
+++ b/src/tunacode/ui/app.py
@@ -384,13 +384,15 @@ class TextualReplApp(App[None]):
             post_stream_started_at = time.monotonic()
 
             final_flush_started_at = time.monotonic()
-            await self._flush_request_deltas()
-            final_flush_ms = (
-                time.monotonic() - final_flush_started_at
-            ) * self.MILLISECONDS_PER_SECOND
-            self._stop_delta_flush_timer()
-            self._request_bridge = None
-            self._current_request_task = None
+            try:
+                await self._flush_request_deltas()
+            finally:
+                final_flush_ms = (
+                    time.monotonic() - final_flush_started_at
+                ) * self.MILLISECONDS_PER_SECOND
+                self._stop_delta_flush_timer()
+                self._request_bridge = None
+                self._current_request_task = None
             if self._loading_indicator_shown:
                 self._request_debug.loading_hidden(reason="request_complete")
             self._hide_loading_indicator()

--- a/src/tunacode/ui/commands/debug.py
+++ b/src/tunacode/ui/commands/debug.py
@@ -20,6 +20,8 @@ class DebugCommand(Command):
         from tunacode.core.debug import log_usage_update
         from tunacode.core.logging import get_logger
 
+        from tunacode.ui.request_debug import build_request_debug_thresholds_message
+
         session = app.state_manager.session
         session.debug_mode = not session.debug_mode
 
@@ -44,8 +46,13 @@ class DebugCommand(Command):
                 "[dim]Input/request latency traces use lifecycle prefixes "
                 "'Input:', 'Queue:', 'Bridge:', 'UI:', and 'Init:'.[/dim]"
             )
+            app.chat_container.write(
+                "[dim]Tail latency now breaks out final_flush, response_panel, "
+                "resource_bar, and save_session timings.[/dim]"
+            )
             logger.info(debug_message)
             logger.info("Lifecycle logging enabled")
+            logger.lifecycle(build_request_debug_thresholds_message())
             log_usage_update(
                 logger=logger,
                 request_id=session.runtime.request_id,

--- a/src/tunacode/ui/request_debug.py
+++ b/src/tunacode/ui/request_debug.py
@@ -18,6 +18,10 @@ DELTA_TIMER_DRIFT_WARN_MS = 125.0
 BRIDGE_BACKLOG_WARN_MS = 200.0
 BRIDGE_FLUSH_WARN_MS = 25.0
 CALLBACK_WARN_MS = 20.0
+POST_STREAM_CLEANUP_WARN_MS = 75.0
+RESPONSE_PANEL_WARN_MS = 40.0
+RESOURCE_BAR_UPDATE_WARN_MS = 25.0
+SAVE_SESSION_WARN_MS = 50.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,6 +82,32 @@ class _RequestMetrics:
     thinking_batches: int = 0
     thinking_chunks: int = 0
     thinking_chars: int = 0
+    worker_ms: float = 0.0
+    final_flush_ms: float = 0.0
+    response_panel_ms: float = 0.0
+    response_chars: int = 0
+    resource_bar_update_ms: float = 0.0
+    save_session_ms: float = 0.0
+    message_count: int = 0
+    post_stream_cleanup_ms: float = 0.0
+
+
+def build_request_debug_thresholds_message() -> str:
+    """Describe the /debug warning thresholds shown to operators."""
+
+    return (
+        "UI: "
+        "thresholds "
+        f"keypress={KEYPRESS_RENDER_WARN_MS:.0f}ms "
+        f"timer_drift={DELTA_TIMER_DRIFT_WARN_MS:.0f}ms "
+        f"bridge_backlog={BRIDGE_BACKLOG_WARN_MS:.0f}ms "
+        f"bridge_flush={BRIDGE_FLUSH_WARN_MS:.0f}ms "
+        f"callbacks={CALLBACK_WARN_MS:.0f}ms "
+        f"response_panel={RESPONSE_PANEL_WARN_MS:.0f}ms "
+        f"resource_bar={RESOURCE_BAR_UPDATE_WARN_MS:.0f}ms "
+        f"save_session={SAVE_SESSION_WARN_MS:.0f}ms "
+        f"post_stream={POST_STREAM_CLEANUP_WARN_MS:.0f}ms"
+    )
 
 
 class RequestDebugTracer:
@@ -170,9 +200,15 @@ class RequestDebugTracer:
             "UI: "
             f"request_trace seq={metrics.sequence_id} "
             f"request={total_request_ms:.1f}ms "
+            f"worker={metrics.worker_ms:.1f}ms "
+            f"post_stream={metrics.post_stream_cleanup_ms:.1f}ms "
             f"loading={self._last_loading_visible_ms:.1f}ms "
             f"submit_to_queue={self._format_ms(metrics.submit_to_queue_ms)} "
             f"queue_to_start={self._format_ms(metrics.queue_to_start_ms)} "
+            f"final_flush={metrics.final_flush_ms:.1f}ms "
+            f"response_panel={metrics.response_panel_ms:.1f}ms "
+            f"resource_bar={metrics.resource_bar_update_ms:.1f}ms "
+            f"save_session={metrics.save_session_ms:.1f}ms "
             f"keypress_max={metrics.max_keypress_to_refresh_ms:.1f}ms "
             f"keypress_slow={metrics.keypress_slow_count}/{metrics.keypress_sample_count} "
             f"timer_drift_max={metrics.max_delta_timer_drift_ms:.1f}ms "
@@ -182,6 +218,55 @@ class RequestDebugTracer:
             f"thinking_cb_max={metrics.max_thinking_callback_ms:.1f}ms"
         )
         self._active_request_metrics = None
+
+    def note_request_worker_completed(self, *, duration_ms: float) -> None:
+        metrics = self._active_request_metrics
+        if metrics is None or not self._enabled:
+            return
+        metrics.worker_ms = duration_ms
+
+    def note_post_stream_cleanup(
+        self,
+        *,
+        final_flush_ms: float,
+        response_panel_ms: float,
+        response_chars: int,
+        resource_bar_update_ms: float,
+        save_session_ms: float,
+        message_count: int,
+        total_cleanup_ms: float,
+    ) -> None:
+        metrics = self._active_request_metrics
+        if metrics is None or not self._enabled:
+            return
+
+        metrics.final_flush_ms = final_flush_ms
+        metrics.response_panel_ms = response_panel_ms
+        metrics.response_chars = response_chars
+        metrics.resource_bar_update_ms = resource_bar_update_ms
+        metrics.save_session_ms = save_session_ms
+        metrics.message_count = message_count
+        metrics.post_stream_cleanup_ms = total_cleanup_ms
+
+        if not self._should_log_post_stream_cleanup(
+            response_panel_ms=response_panel_ms,
+            resource_bar_update_ms=resource_bar_update_ms,
+            save_session_ms=save_session_ms,
+            total_cleanup_ms=total_cleanup_ms,
+        ):
+            return
+
+        self._emit(
+            "UI: "
+            f"post_stream seq={metrics.sequence_id} "
+            f"total={total_cleanup_ms:.1f}ms "
+            f"final_flush={final_flush_ms:.1f}ms "
+            f"response_panel={response_panel_ms:.1f}ms "
+            f"response_chars={response_chars} "
+            f"resource_bar={resource_bar_update_ms:.1f}ms "
+            f"save_session={save_session_ms:.1f}ms "
+            f"messages={message_count}"
+        )
 
     def loading_shown(self, *, reason: str) -> None:
         if not self._enabled:
@@ -359,6 +444,21 @@ class RequestDebugTracer:
             or flush_duration_ms >= BRIDGE_FLUSH_WARN_MS
             or stream_callback_ms >= CALLBACK_WARN_MS
             or thinking_callback_ms >= CALLBACK_WARN_MS
+        )
+
+    def _should_log_post_stream_cleanup(
+        self,
+        *,
+        response_panel_ms: float,
+        resource_bar_update_ms: float,
+        save_session_ms: float,
+        total_cleanup_ms: float,
+    ) -> bool:
+        return (
+            response_panel_ms >= RESPONSE_PANEL_WARN_MS
+            or resource_bar_update_ms >= RESOURCE_BAR_UPDATE_WARN_MS
+            or save_session_ms >= SAVE_SESSION_WARN_MS
+            or total_cleanup_ms >= POST_STREAM_CLEANUP_WARN_MS
         )
 
     def _queue_size(self) -> int:

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -15,6 +15,8 @@ from tinyagent.agent_types import (
     UserMessage,
 )
 
+from tunacode.utils.messaging import estimate_messages_tokens
+
 from tunacode.core.compaction.controller import (
     CompactionController,
     apply_compaction_messages,
@@ -28,7 +30,6 @@ from tunacode.core.compaction.types import (
     CompactionRecord,
 )
 from tunacode.core.session import StateManager
-from tunacode.utils.messaging import estimate_messages_tokens
 
 KEEP_RECENT_TOKENS = 80
 RESERVE_TOKENS = 40

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -28,6 +28,7 @@ from tunacode.core.compaction.types import (
     CompactionRecord,
 )
 from tunacode.core.session import StateManager
+from tunacode.utils.messaging import estimate_messages_tokens
 
 KEEP_RECENT_TOKENS = 80
 RESERVE_TOKENS = 40
@@ -168,6 +169,7 @@ async def test_compaction_flow_end_to_end(tmp_path: Path, monkeypatch: pytest.Mo
     # Controller compaction is side-effect free for conversation history mutation.
     assert conversation.messages == history
     apply_compaction_messages(state_manager, compacted)
+    assert session.conversation.total_tokens == estimate_messages_tokens(compacted)
 
     record = session.compaction
     assert record is not None
@@ -204,6 +206,9 @@ async def test_compaction_flow_end_to_end(tmp_path: Path, monkeypatch: pytest.Mo
     restored = StateManager()
     restored_loaded = await restored.load_session(session.session_id)
     assert restored_loaded
+    assert restored.session.conversation.total_tokens == estimate_messages_tokens(
+        restored.session.conversation.messages
+    )
     assert restored.session.compaction is not None
     assert restored.session.compaction.summary == record.summary
     assert restored.session.compaction.compaction_count == record.compaction_count

--- a/tests/unit/core/test_request_orchestrator_parallel_tools.py
+++ b/tests/unit/core/test_request_orchestrator_parallel_tools.py
@@ -15,12 +15,12 @@ from tinyagent.agent_types import (
 )
 
 from tunacode.types.canonical import ToolCallStatus
+from tunacode.utils.messaging import estimate_messages_tokens
 
 from tunacode.core.agents import main as agent_main
 from tunacode.core.agents.main import RequestOrchestrator, _TinyAgentStreamState
 from tunacode.core.logging.manager import get_logger
 from tunacode.core.session import StateManager
-from tunacode.utils.messaging import estimate_messages_tokens
 
 
 def _build_orchestrator_harness(

--- a/tests/unit/core/test_request_orchestrator_parallel_tools.py
+++ b/tests/unit/core/test_request_orchestrator_parallel_tools.py
@@ -20,6 +20,7 @@ from tunacode.core.agents import main as agent_main
 from tunacode.core.agents.main import RequestOrchestrator, _TinyAgentStreamState
 from tunacode.core.logging.manager import get_logger
 from tunacode.core.session import StateManager
+from tunacode.utils.messaging import estimate_messages_tokens
 
 
 def _build_orchestrator_harness(
@@ -232,3 +233,29 @@ def test_abort_cleanup_reconciles_in_flight_tool_state_and_dangling_messages() -
     content_item = message.content[0]
     assert isinstance(content_item, TextContent)
     assert content_item.text == "[INTERRUPTED]\n\npartial output"
+    assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(
+        state_manager.session.conversation.messages
+    )
+
+
+def test_persist_agent_messages_refreshes_total_tokens() -> None:
+    orchestrator, _state, state_manager = _build_orchestrator_harness(
+        start_events=[],
+        result_events=[],
+    )
+    state_manager.session.conversation.messages = [
+        AssistantMessage(content=[TextContent(text="external")], timestamp=None)
+    ]
+    state_manager.session.conversation.total_tokens = 0
+
+    fake_agent = SimpleNamespace(
+        state=SimpleNamespace(
+            messages=[AssistantMessage(content=[TextContent(text="agent")], timestamp=None)]
+        )
+    )
+
+    orchestrator._persist_agent_messages(fake_agent, baseline_message_count=0)
+
+    assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(
+        state_manager.session.conversation.messages
+    )

--- a/tests/unit/ui/test_request_debug.py
+++ b/tests/unit/ui/test_request_debug.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tunacode.ui.request_bridge import RequestUiBridge
-from tunacode.ui.request_debug import RequestDebugTracer
+from tunacode.ui.request_debug import (
+    RequestDebugTracer,
+    build_request_debug_thresholds_message,
+)
 
 
 class _FakeQueue:
@@ -80,6 +83,62 @@ def test_request_debug_logs_slow_keypress_after_refresh() -> None:
     messages = [call.args[0] for call in logger.lifecycle.call_args_list]
     assert any("Input: keypress_to_refresh seq=1" in message for message in messages)
     assert any("elapsed=250.0ms" in message for message in messages)
+
+
+def test_request_debug_logs_slow_post_stream_cleanup_and_summary() -> None:
+    app = _FakeApp()
+    tracer = RequestDebugTracer(app)
+    logger = MagicMock()
+
+    with (
+        patch("tunacode.ui.request_debug.get_logger", return_value=logger),
+        patch(
+            "tunacode.ui.request_debug.time.monotonic",
+            side_effect=[1.0, 1.010, 1.020],
+        ),
+    ):
+        trace = tracer.submit_received(raw_text="prompt", normalized_text="prompt")
+        tracer.request_enqueued_after_refresh(trace)
+        tracer.request_started(tracer.pop_next_submission_trace())
+        tracer.note_request_worker_completed(duration_ms=410.0)
+        tracer.note_post_stream_cleanup(
+            final_flush_ms=12.0,
+            response_panel_ms=48.0,
+            response_chars=320,
+            resource_bar_update_ms=26.0,
+            save_session_ms=80.0,
+            message_count=42,
+            total_cleanup_ms=130.0,
+        )
+        tracer.request_finished(total_request_ms=560.0)
+
+    messages = [call.args[0] for call in logger.lifecycle.call_args_list]
+    assert any(
+        "UI: post_stream seq=1" in message
+        and "response_panel=48.0ms" in message
+        and "save_session=80.0ms" in message
+        and "messages=42" in message
+        for message in messages
+    )
+    assert any(
+        "UI: request_trace seq=1" in message
+        and "worker=410.0ms" in message
+        and "post_stream=130.0ms" in message
+        and "response_panel=48.0ms" in message
+        and "resource_bar=26.0ms" in message
+        and "save_session=80.0ms" in message
+        for message in messages
+    )
+
+
+def test_build_request_debug_thresholds_message_lists_new_tail_latency_fields() -> None:
+    message = build_request_debug_thresholds_message()
+
+    assert message.startswith("UI: thresholds")
+    assert "response_panel=40ms" in message
+    assert "resource_bar=25ms" in message
+    assert "save_session=50ms" in message
+    assert "post_stream=75ms" in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- cache conversation total token state during request orchestration and persist the refreshed value during agent message handling and compaction flows
- expand request debug instrumentation to surface tail latency, submit/start timing, bridge drain metadata, and slow cleanup/keypress events in the UI debug path
- cover the new behavior with request-debug, orchestration, and compaction tests, and refresh `AGENTS.md`

## Why
The request path needed better token accounting and more actionable debug visibility around slow or delayed request lifecycle phases.

## Impact
Users get more accurate total-token tracking and richer debug output when investigating request timing issues.

## Validation
- `uv run --extra dev python -m pytest tests/test_compaction.py tests/unit/core/test_request_orchestrator_parallel_tools.py tests/unit/ui/test_request_debug.py`
- `uv run python scripts/check_agents_freshness.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## State Management Changes

- Conversation total-token caching is now propagated and maintained across lifecycle:
  - Session restore: StateManager.load_session() recalculates and sets conversation.total_tokens from deserialized messages via estimate_messages_tokens().
  - Message persistence/update paths refresh total_tokens:
    - RequestOrchestrator._persist_agent_messages() recomputes conversation.total_tokens after merging messages.
    - CompactionController.apply_compaction_messages() writes conversation.total_tokens = estimate_messages_tokens(applied_messages) after applying compaction output.
    - RequestOrchestrator._sanitize_conversation_after_abort() recomputes session.conversation.total_tokens when sanitization modifies messages.
  - Incremental append path: _append_interrupted_partial_message() constructs the interrupted message, appends it, and increments session.conversation.total_tokens using estimate_message_tokens(interrupted_message) (single-message estimator), rather than doing a full recomputation.

- CompactionController gains a helper _estimated_tokens(messages) that prefers the cached conversation.total_tokens when the messages list is the same object as session.conversation.messages, avoiding unnecessary re-estimation for the live conversation object.

- Tests updated to assert total_tokens correctness after compaction, session load, abort cleanup, and _persist_agent_messages behavior.

## Exception Handling Paths

- ContextOverflowError handling now reuses cached total_tokens when available:
  - In _retry_after_context_overflow_if_needed, the flow reads conversation.total_tokens and only lazily recomputes estimate_messages_tokens(conversation.messages) when the cached value is 0 and messages exist.
  - The computed estimated_tokens is passed into ContextOverflowError construction (and conversation.total_tokens is set to the recomputed value), so the exception path now has a side-effect of refreshing the cached token count.

- Abort/cleanup paths only recompute total_tokens when cleanup/sanitization actually mutates messages (cleanup_applied gating preserved).

## Type Safety, Estimators, and Consistency

- Estimator usage is explicit and type-appropriate:
  - estimate_message_tokens() used for single-message incremental updates.
  - estimate_messages_tokens() used for full-message-list recalculation.
- conversation.total_tokens remains an int (consistent assignments across paths).
- No public API or exported signature changes; changes are internal behavior and added helper method on CompactionController.

## Dead Code / Regressions

- No dead code introduced; no exported declarations removed.
- Behavioral inconsistency remains between incremental update (+= single-message estimate) and full-recalculation paths:
  - The incremental += approach assumes prior conversation.total_tokens is accurate; if total_tokens is uninitialized or stale (e.g., 0), the increment can produce incorrect totals. Call sites should ensure the cache is valid before relying on incremental updates.
- ContextOverflowError now mutates conversation.total_tokens as a side effect when recomputing—this implicit cache update could be surprising and would benefit from clearer, explicit cache-update semantics.

## Additional Notes

- Request debug instrumentation expanded (worker/post-stream timing and new thresholds) and tests added for request-debug tracing; these changes are orthogonal to state management but improve observability of slow lifecycle phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->