### PR TITLE
Fix #438: replace abort-time cleanup with forward-patch tool call reconciliation

### DIFF
--- a/src/tunacode/core/agents/helpers.py
+++ b/src/tunacode/core/agents/helpers.py
@@ -38,6 +38,7 @@ class _TinyAgentStreamState:
     tool_start_times: dict[str, float]
     active_tool_call_ids: set[str]
     batch_tool_call_ids: set[str]
+    last_stable_agent_message_count: int = 0
     last_assistant_message: AssistantMessage | None = None
 
 

--- a/src/tunacode/core/agents/helpers.py
+++ b/src/tunacode/core/agents/helpers.py
@@ -38,7 +38,6 @@ class _TinyAgentStreamState:
     tool_start_times: dict[str, float]
     active_tool_call_ids: set[str]
     batch_tool_call_ids: set[str]
-    last_stable_agent_message_count: int = 0
     last_assistant_message: AssistantMessage | None = None
 
 

--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -15,17 +15,13 @@ from tinyagent.agent_types import (
     AgentMessage,
     AgentTool,
     AssistantMessage,
-    CustomAgentMessage,
-    JsonObject,
     MessageEndEvent,
     MessageUpdateEvent,
     TextContent,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
-    ToolResultMessage,
     TurnEndEvent,
-    UserMessage,
     is_agent_end_event,
     is_message_end_event,
     is_tool_execution_end_event,
@@ -73,7 +69,6 @@ from .helpers import (
     is_context_overflow_error,
     parse_canonical_usage,
 )
-from .resume import sanitize
 
 REQUEST_ID_LENGTH = 8
 MILLISECONDS_PER_SECOND = 1000
@@ -99,36 +94,6 @@ def _describe_stream_event(event: AgentEvent) -> str:
     if is_agent_end_event(event):
         return "agent_end"
     return type(event).__name__
-
-
-def _serialize_agent_messages(messages: list[AgentMessage]) -> list[object]:
-    serialized_messages: list[object] = []
-    for message in messages:
-        serialized_messages.append(cast(JsonObject, message.model_dump(exclude_none=True)))
-    return serialized_messages
-
-
-def _deserialize_agent_messages(raw_messages: list[object]) -> list[AgentMessage]:
-    deserialized_messages: list[AgentMessage] = []
-    for index, raw_message in enumerate(raw_messages):
-        if not isinstance(raw_message, dict):
-            raise TypeError(
-                "sanitized message must be a dict, "
-                f"got {type(raw_message).__name__} at index {index}"
-            )
-        typed_raw_message = cast(JsonObject, raw_message)
-        role = typed_raw_message.get("role")
-        if role == "user":
-            deserialized_messages.append(UserMessage.model_validate(typed_raw_message))
-            continue
-        if role == "assistant":
-            deserialized_messages.append(AssistantMessage.model_validate(typed_raw_message))
-            continue
-        if role == "tool_result":
-            deserialized_messages.append(ToolResultMessage.model_validate(typed_raw_message))
-            continue
-        deserialized_messages.append(CustomAgentMessage.model_validate(typed_raw_message))
-    return deserialized_messages
 
 
 class RequestOrchestrator:
@@ -374,21 +339,31 @@ class RequestOrchestrator:
         if removed_count > 0:
             logger.lifecycle(f"Removed {removed_count} in-flight tool call(s) after abort")
 
-    def _sanitize_conversation_after_abort(self, logger: LogManager) -> None:
-        session = self.state_manager.session
-        serialized_messages = _serialize_agent_messages(session.conversation.messages)
-        cleanup_applied, dangling_tool_call_ids = sanitize.run_cleanup_loop(
-            serialized_messages,
-            session.runtime.tool_registry,
-        )
-        if cleanup_applied:
-            session.conversation.messages = _deserialize_agent_messages(serialized_messages)
-            session.conversation.total_tokens = estimate_messages_tokens(
-                session.conversation.messages
-            )
-        if cleanup_applied and dangling_tool_call_ids:
+    def _rollback_to_last_stable_turn(
+        self,
+        logger: LogManager,
+        *,
+        agent: Agent,
+        baseline_message_count: int,
+    ) -> None:
+        active_state = self._active_stream_state
+        if active_state is None:
+            self._persist_agent_messages(agent, baseline_message_count)
+            return
+
+        stable_count = active_state.last_stable_agent_message_count
+        all_agent_messages = list(agent.state.messages)
+        rolled_back_messages = all_agent_messages[:stable_count]
+        dropped_count = len(all_agent_messages) - stable_count
+
+        conversation = self.state_manager.session.conversation
+        external_messages = list(conversation.messages[baseline_message_count:])
+        conversation.messages = [*rolled_back_messages, *external_messages]
+        conversation.total_tokens = estimate_messages_tokens(conversation.messages)
+
+        if dropped_count > 0:
             logger.lifecycle(
-                f"Cleaned up {len(dangling_tool_call_ids)} dangling tool call(s) after abort"
+                f"Rolled back {dropped_count} in-flight message(s) to last stable turn"
             )
 
     def _append_interrupted_partial_message(self) -> None:
@@ -423,6 +398,7 @@ class RequestOrchestrator:
         baseline_message_count: int,
     ) -> bool:
         _ = (event_obj, baseline_message_count)
+        state.last_stable_agent_message_count = len(agent.state.messages)
         state.runtime.iteration_count += 1
         state.runtime.current_iteration = state.runtime.iteration_count
         if state.runtime.iteration_count <= max_iterations:
@@ -652,6 +628,7 @@ class RequestOrchestrator:
             tool_start_times={},
             active_tool_call_ids=set(),
             batch_tool_call_ids=set(),
+            last_stable_agent_message_count=len(agent.state.messages),
         )
         self._active_stream_state = state
         started_at = time.perf_counter()
@@ -660,6 +637,7 @@ class RequestOrchestrator:
         first_event_ms: float | None = None
         last_event_at = started_at
         logger.lifecycle(f"Stream: start thread={stream_thread_id}")
+        stream_completed = False
         try:
             async for event in agent.stream(self.message):
                 now = time.perf_counter()
@@ -692,8 +670,10 @@ class RequestOrchestrator:
                 )
                 if should_stop:
                     break
+            stream_completed = True
         finally:
-            self._active_stream_state = None
+            if stream_completed:
+                self._active_stream_state = None
 
         elapsed_ms = (time.perf_counter() - started_at) * MILLISECONDS_PER_SECOND
         if first_event_ms is None:
@@ -736,11 +716,15 @@ class RequestOrchestrator:
         invalidate_cache: bool = False,
     ) -> None:
         if agent is not None and baseline_message_count is not None:
-            self._persist_agent_messages(agent, baseline_message_count)
+            self._rollback_to_last_stable_turn(
+                logger,
+                agent=agent,
+                baseline_message_count=baseline_message_count,
+            )
 
         self._remove_in_flight_tool_registry_entries(logger)
-        self._sanitize_conversation_after_abort(logger)
         self._append_interrupted_partial_message()
+        self._active_stream_state = None
         if invalidate_cache and ac.invalidate_agent_cache(self.model, self.state_manager):
             logger.lifecycle("Agent cache invalidated after abort")
 

--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -99,33 +99,27 @@ def _describe_stream_event(event: AgentEvent) -> str:
 
 
 def _patch_dangling_tool_calls(messages: list[AgentMessage]) -> int:
-    """Inject error ToolResultMessages for tool_use blocks without matching results.
-
-    Scans backward for the last AssistantMessage with ToolCallContent, collects
-    which tool_call_ids already have a ToolResultMessage after it, and injects
-    a synthetic aborted ToolResultMessage for each unmatched id.
-
-    Returns the number of synthetic results injected.
-    """
+    """Append aborted ToolResultMessages for tool calls left without a result."""
     last_assistant_idx: int | None = None
     pending_tool_call_ids: dict[str, str] = {}
 
-    for i in range(len(messages) - 1, -1, -1):
-        msg = messages[i]
-        if not isinstance(msg, AssistantMessage):
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if not isinstance(message, AssistantMessage):
             continue
-        tool_calls = [c for c in msg.content if isinstance(c, ToolCallContent) and c.id]
-        if tool_calls:
-            last_assistant_idx = i
-            pending_tool_call_ids = {c.id: (c.name or "unknown") for c in tool_calls}  # type: ignore[misc]
+        for content in message.content:
+            if isinstance(content, ToolCallContent) and content.id:
+                pending_tool_call_ids[content.id] = content.name or "unknown"
+        if pending_tool_call_ids:
+            last_assistant_idx = index
             break
 
-    if last_assistant_idx is None or not pending_tool_call_ids:
+    if last_assistant_idx is None:
         return 0
 
-    for msg in messages[last_assistant_idx + 1 :]:
-        if isinstance(msg, ToolResultMessage) and msg.tool_call_id:
-            pending_tool_call_ids.pop(msg.tool_call_id, None)
+    for message in messages[last_assistant_idx + 1 :]:
+        if isinstance(message, ToolResultMessage) and message.tool_call_id:
+            pending_tool_call_ids.pop(message.tool_call_id, None)
 
     if not pending_tool_call_ids:
         return 0
@@ -434,7 +428,7 @@ class RequestOrchestrator:
         max_iterations: int,
         baseline_message_count: int,
     ) -> bool:
-        _ = (event_obj, agent, baseline_message_count)
+        _ = (event_obj, baseline_message_count)
         state.runtime.iteration_count += 1
         state.runtime.current_iteration = state.runtime.iteration_count
         if state.runtime.iteration_count <= max_iterations:

--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -18,9 +18,11 @@ from tinyagent.agent_types import (
     MessageEndEvent,
     MessageUpdateEvent,
     TextContent,
+    ToolCallContent,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
+    ToolResultMessage,
     TurnEndEvent,
     is_agent_end_event,
     is_message_end_event,
@@ -94,6 +96,51 @@ def _describe_stream_event(event: AgentEvent) -> str:
     if is_agent_end_event(event):
         return "agent_end"
     return type(event).__name__
+
+
+def _patch_dangling_tool_calls(messages: list[AgentMessage]) -> int:
+    """Inject error ToolResultMessages for tool_use blocks without matching results.
+
+    Scans backward for the last AssistantMessage with ToolCallContent, collects
+    which tool_call_ids already have a ToolResultMessage after it, and injects
+    a synthetic aborted ToolResultMessage for each unmatched id.
+
+    Returns the number of synthetic results injected.
+    """
+    last_assistant_idx: int | None = None
+    pending_tool_call_ids: dict[str, str] = {}
+
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, AssistantMessage):
+            continue
+        tool_calls = [c for c in msg.content if isinstance(c, ToolCallContent) and c.id]
+        if tool_calls:
+            last_assistant_idx = i
+            pending_tool_call_ids = {c.id: (c.name or "unknown") for c in tool_calls}  # type: ignore[misc]
+            break
+
+    if last_assistant_idx is None or not pending_tool_call_ids:
+        return 0
+
+    for msg in messages[last_assistant_idx + 1 :]:
+        if isinstance(msg, ToolResultMessage) and msg.tool_call_id:
+            pending_tool_call_ids.pop(msg.tool_call_id, None)
+
+    if not pending_tool_call_ids:
+        return 0
+
+    for tool_call_id, tool_name in pending_tool_call_ids.items():
+        messages.append(
+            ToolResultMessage(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                content=[TextContent(text="Tool execution aborted")],
+                is_error=True,
+            )
+        )
+
+    return len(pending_tool_call_ids)
 
 
 class RequestOrchestrator:
@@ -339,32 +386,22 @@ class RequestOrchestrator:
         if removed_count > 0:
             logger.lifecycle(f"Removed {removed_count} in-flight tool call(s) after abort")
 
-    def _rollback_to_last_stable_turn(
+    def _forward_patch_dangling_tool_calls(
         self,
         logger: LogManager,
         *,
         agent: Agent,
         baseline_message_count: int,
     ) -> None:
-        active_state = self._active_stream_state
-        if active_state is None:
-            self._persist_agent_messages(agent, baseline_message_count)
-            return
-
-        stable_count = active_state.last_stable_agent_message_count
-        all_agent_messages = list(agent.state.messages)
-        rolled_back_messages = all_agent_messages[:stable_count]
-        dropped_count = len(all_agent_messages) - stable_count
+        agent_messages = list(agent.state.messages)
+        patched = _patch_dangling_tool_calls(agent_messages)
+        if patched > 0:
+            logger.lifecycle(f"Injected {patched} aborted tool result(s) for dangling calls")
 
         conversation = self.state_manager.session.conversation
         external_messages = list(conversation.messages[baseline_message_count:])
-        conversation.messages = [*rolled_back_messages, *external_messages]
+        conversation.messages = [*agent_messages, *external_messages]
         conversation.total_tokens = estimate_messages_tokens(conversation.messages)
-
-        if dropped_count > 0:
-            logger.lifecycle(
-                f"Rolled back {dropped_count} in-flight message(s) to last stable turn"
-            )
 
     def _append_interrupted_partial_message(self) -> None:
         session = self.state_manager.session
@@ -397,8 +434,7 @@ class RequestOrchestrator:
         max_iterations: int,
         baseline_message_count: int,
     ) -> bool:
-        _ = (event_obj, baseline_message_count)
-        state.last_stable_agent_message_count = len(agent.state.messages)
+        _ = (event_obj, agent, baseline_message_count)
         state.runtime.iteration_count += 1
         state.runtime.current_iteration = state.runtime.iteration_count
         if state.runtime.iteration_count <= max_iterations:
@@ -628,7 +664,6 @@ class RequestOrchestrator:
             tool_start_times={},
             active_tool_call_ids=set(),
             batch_tool_call_ids=set(),
-            last_stable_agent_message_count=len(agent.state.messages),
         )
         self._active_stream_state = state
         started_at = time.perf_counter()
@@ -716,7 +751,7 @@ class RequestOrchestrator:
         invalidate_cache: bool = False,
     ) -> None:
         if agent is not None and baseline_message_count is not None:
-            self._rollback_to_last_stable_turn(
+            self._forward_patch_dangling_tool_calls(
                 logger,
                 agent=agent,
                 baseline_message_count=baseline_message_count,

--- a/src/tunacode/core/agents/main.py
+++ b/src/tunacode/core/agents/main.py
@@ -107,11 +107,16 @@ def _patch_dangling_tool_calls(messages: list[AgentMessage]) -> int:
         message = messages[index]
         if not isinstance(message, AssistantMessage):
             continue
-        for content in message.content:
-            if isinstance(content, ToolCallContent) and content.id:
-                pending_tool_call_ids[content.id] = content.name or "unknown"
-        if pending_tool_call_ids:
+        tool_calls = [
+            content
+            for content in message.content
+            if isinstance(content, ToolCallContent) and content.id
+        ]
+        if tool_calls:
             last_assistant_idx = index
+            pending_tool_call_ids = {
+                cast(str, tool_call.id): tool_call.name or "unknown" for tool_call in tool_calls
+            }
             break
 
     if last_assistant_idx is None:

--- a/tests/unit/core/test_request_orchestrator_parallel_tools.py
+++ b/tests/unit/core/test_request_orchestrator_parallel_tools.py
@@ -12,6 +12,7 @@ from tinyagent.agent_types import (
     ToolCallContent,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
+    UserMessage,
 )
 
 from tunacode.types.canonical import ToolCallStatus
@@ -191,6 +192,7 @@ def test_abort_cleanup_reconciles_in_flight_tool_state_and_dangling_messages() -
         result_events=[],
     )
     state.active_tool_call_ids.add("tool-a")
+    state.last_stable_agent_message_count = 0
     orchestrator._active_stream_state = state
 
     registry = state_manager.session.runtime.tool_registry
@@ -224,6 +226,7 @@ def test_abort_cleanup_reconciles_in_flight_tool_state_and_dangling_messages() -
     )
 
     assert registry.get("tool-a") is None
+    assert orchestrator._active_stream_state is None
     assert len(state_manager.session.conversation.messages) == 1
 
     message = state_manager.session.conversation.messages[0]
@@ -236,6 +239,68 @@ def test_abort_cleanup_reconciles_in_flight_tool_state_and_dangling_messages() -
     assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(
         state_manager.session.conversation.messages
     )
+
+
+def test_abort_rollback_preserves_completed_turns_and_drops_in_flight() -> None:
+    orchestrator, state, state_manager = _build_orchestrator_harness(
+        start_events=[],
+        result_events=[],
+    )
+
+    completed_assistant = AssistantMessage(
+        content=[TextContent(text="completed response")],
+        stop_reason="complete",
+        timestamp=None,
+    )
+    completed_user = UserMessage(
+        content=[TextContent(text="follow-up")],
+    )
+    in_flight_assistant = AssistantMessage(
+        content=[
+            ToolCallContent(
+                id="tool-b",
+                name="write_file",
+                arguments={"path": "x.py"},
+            )
+        ],
+        stop_reason="tool_calls",
+        timestamp=None,
+    )
+
+    fake_agent = SimpleNamespace(
+        state=SimpleNamespace(messages=[completed_assistant, completed_user, in_flight_assistant])
+    )
+
+    state.active_tool_call_ids.add("tool-b")
+    state.last_stable_agent_message_count = 2
+    orchestrator._active_stream_state = state
+
+    registry = state_manager.session.runtime.tool_registry
+    registry.register("tool-b", "write_file", {"path": "x.py"})
+    registry.start("tool-b")
+    state_manager.session._debug_raw_stream_accum = "partial write"
+
+    orchestrator._handle_abort_cleanup(
+        get_logger(),
+        agent=fake_agent,
+        baseline_message_count=0,
+        invalidate_cache=False,
+    )
+
+    assert registry.get("tool-b") is None
+    assert orchestrator._active_stream_state is None
+
+    messages = state_manager.session.conversation.messages
+    assert len(messages) == 3
+
+    assert isinstance(messages[0], AssistantMessage)
+    assert messages[0].content[0].text == "completed response"
+    assert isinstance(messages[1], UserMessage)
+
+    assert isinstance(messages[2], AssistantMessage)
+    assert messages[2].content[0].text == "[INTERRUPTED]\n\npartial write"
+
+    assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(messages)
 
 
 def test_persist_agent_messages_refreshes_total_tokens() -> None:

--- a/tests/unit/core/test_request_orchestrator_parallel_tools.py
+++ b/tests/unit/core/test_request_orchestrator_parallel_tools.py
@@ -22,8 +22,8 @@ from tunacode.utils.messaging import estimate_messages_tokens
 from tunacode.core.agents import main as agent_main
 from tunacode.core.agents.main import (
     RequestOrchestrator,
-    _TinyAgentStreamState,
     _patch_dangling_tool_calls,
+    _TinyAgentStreamState,
 )
 from tunacode.core.logging.manager import get_logger
 from tunacode.core.session import StateManager
@@ -341,9 +341,7 @@ def test_abort_preserves_completed_tool_results_and_patches_remaining() -> None:
         is_error=False,
     )
 
-    fake_agent = SimpleNamespace(
-        state=SimpleNamespace(messages=[assistant_msg, completed_result])
-    )
+    fake_agent = SimpleNamespace(state=SimpleNamespace(messages=[assistant_msg, completed_result]))
 
     state.active_tool_call_ids.add("tool-b")
     orchestrator._active_stream_state = state
@@ -411,7 +409,9 @@ def test_patch_dangling_tool_calls_noop_when_all_matched() -> None:
             stop_reason="tool_calls",
             timestamp=None,
         ),
-        ToolResultMessage(tool_call_id="t1", tool_name="read_file", content=[TextContent(text="ok")]),
+        ToolResultMessage(
+            tool_call_id="t1", tool_name="read_file", content=[TextContent(text="ok")]
+        ),
     ]
     assert _patch_dangling_tool_calls(messages) == 0
     assert len(messages) == 2

--- a/tests/unit/core/test_request_orchestrator_parallel_tools.py
+++ b/tests/unit/core/test_request_orchestrator_parallel_tools.py
@@ -12,6 +12,7 @@ from tinyagent.agent_types import (
     ToolCallContent,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
+    ToolResultMessage,
     UserMessage,
 )
 
@@ -19,7 +20,11 @@ from tunacode.types.canonical import ToolCallStatus
 from tunacode.utils.messaging import estimate_messages_tokens
 
 from tunacode.core.agents import main as agent_main
-from tunacode.core.agents.main import RequestOrchestrator, _TinyAgentStreamState
+from tunacode.core.agents.main import (
+    RequestOrchestrator,
+    _TinyAgentStreamState,
+    _patch_dangling_tool_calls,
+)
 from tunacode.core.logging.manager import get_logger
 from tunacode.core.session import StateManager
 
@@ -186,13 +191,12 @@ async def test_single_tool_duration_is_reported_when_not_in_parallel_batch(
     assert result_events[0][4] == pytest.approx(500.0)
 
 
-def test_abort_cleanup_reconciles_in_flight_tool_state_and_dangling_messages() -> None:
+def test_abort_cleanup_patches_dangling_tool_calls_and_appends_interrupted() -> None:
     orchestrator, state, state_manager = _build_orchestrator_harness(
         start_events=[],
         result_events=[],
     )
     state.active_tool_call_ids.add("tool-a")
-    state.last_stable_agent_message_count = 0
     orchestrator._active_stream_state = state
 
     registry = state_manager.session.runtime.tool_registry
@@ -227,21 +231,26 @@ def test_abort_cleanup_reconciles_in_flight_tool_state_and_dangling_messages() -
 
     assert registry.get("tool-a") is None
     assert orchestrator._active_stream_state is None
-    assert len(state_manager.session.conversation.messages) == 1
 
-    message = state_manager.session.conversation.messages[0]
-    assert isinstance(message, AssistantMessage)
-    assert len(message.content) == 1
+    messages = state_manager.session.conversation.messages
+    assert len(messages) == 3
 
-    content_item = message.content[0]
-    assert isinstance(content_item, TextContent)
-    assert content_item.text == "[INTERRUPTED]\n\npartial output"
-    assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(
-        state_manager.session.conversation.messages
-    )
+    assert isinstance(messages[0], AssistantMessage)
+    assert isinstance(messages[0].content[0], ToolCallContent)
+    assert messages[0].content[0].id == "tool-a"
+
+    assert isinstance(messages[1], ToolResultMessage)
+    assert messages[1].tool_call_id == "tool-a"
+    assert messages[1].is_error is True
+    assert messages[1].content[0].text == "Tool execution aborted"
+
+    assert isinstance(messages[2], AssistantMessage)
+    assert messages[2].content[0].text == "[INTERRUPTED]\n\npartial output"
+
+    assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(messages)
 
 
-def test_abort_rollback_preserves_completed_turns_and_drops_in_flight() -> None:
+def test_abort_forward_patches_in_flight_turn_and_preserves_completed() -> None:
     orchestrator, state, state_manager = _build_orchestrator_harness(
         start_events=[],
         result_events=[],
@@ -272,7 +281,6 @@ def test_abort_rollback_preserves_completed_turns_and_drops_in_flight() -> None:
     )
 
     state.active_tool_call_ids.add("tool-b")
-    state.last_stable_agent_message_count = 2
     orchestrator._active_stream_state = state
 
     registry = state_manager.session.runtime.tool_registry
@@ -291,14 +299,84 @@ def test_abort_rollback_preserves_completed_turns_and_drops_in_flight() -> None:
     assert orchestrator._active_stream_state is None
 
     messages = state_manager.session.conversation.messages
-    assert len(messages) == 3
+    assert len(messages) == 5
 
     assert isinstance(messages[0], AssistantMessage)
     assert messages[0].content[0].text == "completed response"
     assert isinstance(messages[1], UserMessage)
 
     assert isinstance(messages[2], AssistantMessage)
-    assert messages[2].content[0].text == "[INTERRUPTED]\n\npartial write"
+    assert isinstance(messages[2].content[0], ToolCallContent)
+    assert messages[2].content[0].id == "tool-b"
+
+    assert isinstance(messages[3], ToolResultMessage)
+    assert messages[3].tool_call_id == "tool-b"
+    assert messages[3].is_error is True
+    assert messages[3].content[0].text == "Tool execution aborted"
+
+    assert isinstance(messages[4], AssistantMessage)
+    assert messages[4].content[0].text == "[INTERRUPTED]\n\npartial write"
+
+    assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(messages)
+
+
+def test_abort_preserves_completed_tool_results_and_patches_remaining() -> None:
+    orchestrator, state, state_manager = _build_orchestrator_harness(
+        start_events=[],
+        result_events=[],
+    )
+
+    assistant_msg = AssistantMessage(
+        content=[
+            ToolCallContent(id="tool-a", name="read_file", arguments={"filepath": "a.py"}),
+            ToolCallContent(id="tool-b", name="write_file", arguments={"path": "x.py"}),
+        ],
+        stop_reason="tool_calls",
+        timestamp=None,
+    )
+    completed_result = ToolResultMessage(
+        tool_call_id="tool-a",
+        tool_name="read_file",
+        content=[TextContent(text="file contents here")],
+        is_error=False,
+    )
+
+    fake_agent = SimpleNamespace(
+        state=SimpleNamespace(messages=[assistant_msg, completed_result])
+    )
+
+    state.active_tool_call_ids.add("tool-b")
+    orchestrator._active_stream_state = state
+
+    registry = state_manager.session.runtime.tool_registry
+    registry.register("tool-b", "write_file", {"path": "x.py"})
+    registry.start("tool-b")
+    state_manager.session._debug_raw_stream_accum = ""
+
+    orchestrator._handle_abort_cleanup(
+        get_logger(),
+        agent=fake_agent,
+        baseline_message_count=0,
+        invalidate_cache=False,
+    )
+
+    assert registry.get("tool-b") is None
+
+    messages = state_manager.session.conversation.messages
+    assert len(messages) == 3
+
+    assert isinstance(messages[0], AssistantMessage)
+    assert len(messages[0].content) == 2
+
+    assert isinstance(messages[1], ToolResultMessage)
+    assert messages[1].tool_call_id == "tool-a"
+    assert messages[1].is_error is False
+    assert messages[1].content[0].text == "file contents here"
+
+    assert isinstance(messages[2], ToolResultMessage)
+    assert messages[2].tool_call_id == "tool-b"
+    assert messages[2].is_error is True
+    assert messages[2].content[0].text == "Tool execution aborted"
 
     assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(messages)
 
@@ -324,3 +402,51 @@ def test_persist_agent_messages_refreshes_total_tokens() -> None:
     assert state_manager.session.conversation.total_tokens == estimate_messages_tokens(
         state_manager.session.conversation.messages
     )
+
+
+def test_patch_dangling_tool_calls_noop_when_all_matched() -> None:
+    messages: list = [
+        AssistantMessage(
+            content=[ToolCallContent(id="t1", name="read_file", arguments={})],
+            stop_reason="tool_calls",
+            timestamp=None,
+        ),
+        ToolResultMessage(tool_call_id="t1", tool_name="read_file", content=[TextContent(text="ok")]),
+    ]
+    assert _patch_dangling_tool_calls(messages) == 0
+    assert len(messages) == 2
+
+
+def test_patch_dangling_tool_calls_noop_when_no_tool_calls() -> None:
+    messages: list = [
+        AssistantMessage(content=[TextContent(text="hello")], timestamp=None),
+    ]
+    assert _patch_dangling_tool_calls(messages) == 0
+    assert len(messages) == 1
+
+
+def test_patch_dangling_tool_calls_injects_for_multiple_missing() -> None:
+    messages: list = [
+        AssistantMessage(
+            content=[
+                ToolCallContent(id="t1", name="read_file", arguments={}),
+                ToolCallContent(id="t2", name="write_file", arguments={}),
+                ToolCallContent(id="t3", name="bash", arguments={}),
+            ],
+            stop_reason="tool_calls",
+            timestamp=None,
+        ),
+        ToolResultMessage(
+            tool_call_id="t1", tool_name="read_file", content=[TextContent(text="done")]
+        ),
+    ]
+    patched = _patch_dangling_tool_calls(messages)
+    assert patched == 2
+    assert len(messages) == 4
+
+    injected_ids = {m.tool_call_id for m in messages[2:]}
+    assert injected_ids == {"t2", "t3"}
+    for msg in messages[2:]:
+        assert isinstance(msg, ToolResultMessage)
+        assert msg.is_error is True
+        assert msg.content[0].text == "Tool execution aborted"


### PR DESCRIPTION
## Description
Replaces the legacy abort-time cleanup path with a tinyagent-native **forward-patch** approach. This supersedes the closed PR #454 and fixes the correctness bug raised in that review by @tunahorse.

**The bug from #454:**  
That PR truncated `agent.state.messages` to a `last_stable_agent_message_count` watermark advanced only on `TurnEndEvent`. But in tinyagent, completed `tool_result` messages are appended to `agent.state.messages` *before* `TurnEndEvent` fires. An abort that landed mid-turn, after a tool had already executed and written its result, would silently erase that completed result from history. The tool's side effects (file writes, shell commands) would persist on disk, but the conversation would no longer reflect them, creating divergence between conversation state and filesystem state.

**This PR's approach:**  
Instead of rolling back history, this scans the last assistant message for `ToolCallContent` blocks, finds which `tool_call_id`s lack matching `ToolResultMessage`s, and injects synthetic `is_error=True` `ToolResultMessage`s for the unmatched ones. Completed tool results stay in history. Aborted ones get an explicit error marker. Every `tool_use` ends up with a matching `tool_result`, so the conversation stays valid for the next turn and history matches what actually happened on disk.

Closes #438.

**Key changes:**

- `src/tunacode/core/agents/main.py`
  - Added `_patch_dangling_tool_calls()` — a pure function operating on `list[AgentMessage]` that scans for the last assistant message with tool calls and injects error `tool_result`s for unmatched IDs
  - Replaced `_rollback_to_last_stable_turn` with `_forward_patch_dangling_tool_calls`
  - Removed watermark update from `_handle_stream_turn_end`
  - Removed watermark initialization from `_run_stream`

- `src/tunacode/core/agents/helpers.py`
  - Removed `last_stable_agent_message_count` from `_TinyAgentStreamState` (no watermark needed)

- `tests/unit/core/test_request_orchestrator_parallel_tools.py`
  - Rewrote both abort tests to assert forward-patch semantics
  - Added `test_abort_preserves_completed_tool_results_and_patches_remaining` — direct regression test for the #454 bug
  - Added 3 unit tests for `_patch_dangling_tool_calls` directly

This operates entirely on `list[AgentMessage]` — no `AgentMessage → dict → ResumeMessage → dict → AgentMessage` round-trip. `sanitize.py` is left intact for the resume/persistence boundary (the issue's "true boundaries" carve-out) but has zero production callers from the runtime abort path.

## Pre-PR Checklist
- [x] **Rebased onto master** (`git fetch origin && git rebase origin/master`)
- [x] **All pre-commit hooks pass** (`uv run pre-commit run --all-files`)
- [ ] Tech debt baseline updated (if adding TODO/FIXME markers: `uv run python scripts/todo_scanner.py --output scripts/todo_baseline.json`) — N/A, no new TODO/FIXME markers added

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test improvement
- [x] Refactoring (code improvement without changing functionality)
- [x] Tool/Agent enhancement (improvements to LLM tools or agents)

## Testing
- [x] All existing tests pass (`uv run pytest`) — 233 passed in `tests/unit`, 4 passed + 1 skipped in `tests/integration`
- [x] New tests have been added to cover the changes
- [ ] Tests have been run locally
- [ ] Golden/character tests established for new features — N/A, this is a bug fix on existing functionality

### Test Coverage
New tests added and passing locally:

| Test | What it verifies |
|---|---|
| `test_abort_cleanup_patches_dangling_tool_calls_and_appends_interrupted` | Single dangling tool call → assistant message stays, error `tool_result` injected, `[INTERRUPTED]` appended |
| `test_abort_forward_patches_in_flight_turn_and_preserves_completed` | Multi-turn: completed prior turn untouched, in-flight turn forward-patched |
| `test_abort_preserves_completed_tool_results_and_patches_remaining` | Regression test for the #454 bug — 2 tool calls requested, tool A's real result already in history, abort lands. Asserts: tool A's real result survives, tool B gets a synthetic `is_error=True` `"Tool execution aborted"` result |
| `test_patch_dangling_tool_calls_noop_when_all_matched` | No-op when every `tool_use` already has a matching result |
| `test_patch_dangling_tool_calls_noop_when_no_tool_calls` | No-op when assistant message has no tool calls |
| `test_patch_dangling_tool_calls_injects_for_multiple_missing` | 3 `tool_use`s, 1 completed → 2 error results injected for the unmatched IDs |

- Current coverage: ___%
- Coverage after changes: ___%

## Pre-commit Checks
- [x] All pre-commit hooks pass
- [x] Code formatted with `ruff format`
- [x] Code passes `ruff check` without warnings
- [x] No Python file exceeds **600 lines** — `main.py` (794 lines) has the pre-existing exemption in `scripts/check-file-length.sh`

## Checklist
- [x] My code follows the Python coding standards (type hints, f-strings, pathlib, etc.)
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated documentation in `@documentation/` and `.claude/` directories — N/A, no existing docs reference the abort path
- [x] My changes generate no new warnings
- [x] Dependencies are properly managed in `pyproject.toml` — no dependency changes
- [x] Any dependent changes have been merged and published — none required
- [x] Created rollback point with clear commit message before changes — sits on top of `replace abort-time` (prior approach) and `implement forward patch` (this fix)

## Documentation Updates
- [ ] Updated relevant files in `@documentation/` — N/A, no doc references the abort path
- [ ] Updated developer notes in `.claude/` — N/A
- [ ] README.md updated (if needed) — N/A

## Additional Notes

### Confirmation that this fixes the #454 review feedback
The bug raised by @tunahorse in #454 was:

> `_rollback_to_last_stable_turn()` truncates history to `last_stable_agent_message_count`, but is only advanced on `TurnEndEvent`. In tinyagent, a completed `tool_result` message is emitted and appended to `agent.state.messages` before `TurnEndEvent`.

This PR removes both `_rollback_to_last_stable_turn` and `last_stable_agent_message_count` entirely. There is no watermark, no truncation, and therefore no possibility of dropping a completed-but-not-yet-acknowledged tool result. The forward-patch approach is immune to the ordering issue because it operates on `agent.state.messages` exactly as they exist at abort time and only *adds* synthetic results for `tool_call_id`s that are missing. It never removes anything.

The regression test `test_abort_preserves_completed_tool_results_and_patches_remaining` constructs exactly the scenario from the review: an assistant message requesting two tools, one `ToolResultMessage` already appended (representing a tool that ran to completion before abort), and asserts the completed result survives the abort cleanup while the unfinished one gets an error marker.

### Strategy comparison vs. #454

| Aspect | #454 (closed) | This PR |
|---|---|---|
| Strategy | Truncate to last `TurnEndEvent` watermark | Forward-patch dangling tool calls in place |
| State on `_TinyAgentStreamState` | Adds `last_stable_agent_message_count: int` | Adds nothing |
| Mid-turn abort with completed tools | Drops completed tool results | Preserves them |
| Conversation/filesystem alignment after abort | Diverges (history lies about what ran) | Stays aligned |
| `AgentMessage → dict → ResumeMessage` round-trip | Removed | Removed |
| `_remove_in_flight_tool_registry_entries` works correctly | Yes | Yes (carried forward) |

`sanitize.py` and `run_cleanup_loop` remain available for the session resume boundary but have zero production callers from the runtime abort path (verified by grep across `src/`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## State Management Changes

- Removed watermark-based abort rollback: `last_stable_agent_message_count` was deleted from `_TinyAgentStreamState` (helpers.py), eliminating the prior watermark/truncation mechanism.
- Stream state clearing is now conditional during abort handling: `_active_stream_state` is left to be cleared as part of the abort cleanup flow (cleared when removing in-flight registry entries and after forward-patching) rather than unconditionally during stream finally/unconditional teardown.
- Message history preservation & merging: abort path no longer truncates `agent.state.messages`. Instead, the orchestrator collects agent messages, applies forward-patch fixes for dangling tool calls, then merges the patched agent messages with the external conversation tail (messages after `baseline_message_count`) and recomputes `conversation.total_tokens` (no AgentMessage → dict → ResumeMessage round-trip).

## Exception Handling Path Changes

- Replaced abort-time sanitize/rollback with forward-patch:
  - New pure helper `_patch_dangling_tool_calls(messages: list[AgentMessage]) -> int` scans backward to the last `AssistantMessage` with `ToolCallContent`, computes tool call IDs that lack a subsequent `ToolResultMessage`, and appends synthetic `ToolResultMessage` entries with `is_error=True` and content text "Tool execution aborted".
  - `_forward_patch_dangling_tool_calls` (RequestOrchestrator) uses `_patch_dangling_tool_calls` to mutate a copy of `agent.state.messages`, logs injected counts, then persists agent+external messages back to the session conversation.
- Completed tool results are preserved: only in-flight/dangling tool calls receive synthetic error `ToolResultMessage`s; existing successful `ToolResultMessage`s are left intact.
- In-flight tool registry cleanup remains: `_remove_in_flight_tool_registry_entries()` removes unresolved tool registry entries on abort (and tests assert registry entries are removed).

## Type Safety

- Patched messages use native tinyagent types (`ToolResultMessage`, `TextContent`) and the helper and orchestrator manipulate typed lists (`list[AgentMessage]`) directly — the runtime abort path no longer serializes to/from dicts, avoiding contract conversions.
- No new public API/type declarations were added or changed; helper code continues to coerce/canonicalize tool results via existing typed helpers. Tests exercise typed constructs (ToolCallContent, ToolResultMessage, AssistantMessage, UserMessage).

## Dead Code Removed / Dependencies Removed

- Removed the serialize/deserialize abort cleanup round-trip and the `sanitize.run_cleanup_loop()` usage from the runtime abort path.
- Watermark initialization and update logic (watermark-based rollback related code) was removed.
- The abort path now avoids using the sanitize-based cleanup; `sanitize` is not referenced from the runtime abort flow.

## Tests

- Updated and extended unit tests (tests/unit/core/test_request_orchestrator_parallel_tools.py) to assert forward-patch semantics:
  - Existing abort cleanup test rewritten to expect injected `ToolResultMessage` (is_error=True) + interrupted assistant message.
  - Added tests covering preservation of completed results while patching in-flight tool calls.
  - Added direct unit tests for `_patch_dangling_tool_calls` to validate no-op and injection behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->