### PR TITLE
refactor: simplify ignore_patterns module

### DIFF
--- a/src/tunacode/configuration/ignore_patterns.py
+++ b/src/tunacode/configuration/ignore_patterns.py
@@ -11,14 +11,9 @@ import pathspec
 from tunacode.constants import ENV_FILE
 
 GITIGNORE_FILE_NAME: Final[str] = ".gitignore"
-GITIGNORE_STYLE: Final[str] = "gitwildmatch"
-TEXT_ENCODING: Final[str] = "utf-8"
-GIT_DIR_PATTERN: Final[str] = ".git/"
-WILDCARD_CHARS = ("*", "?", "[")
-EMPTY_IGNORE_PATTERNS: Final[tuple[str, ...]] = ()
 
 DEFAULT_IGNORE_PATTERNS: Final[tuple[str, ...]] = (
-    GIT_DIR_PATTERN,
+    ".git/",
     ".hg/",
     ".svn/",
     ".bzr/",
@@ -72,42 +67,31 @@ DEFAULT_IGNORE_PATTERNS: Final[tuple[str, ...]] = (
     ENV_FILE,
 )
 
+_WILDCARD_CHARS = ("*", "?", "[")
 
-def _is_literal_dir_pattern(pattern: str) -> bool:
-    return pattern.endswith("/") and not any(char in pattern for char in WILDCARD_CHARS)
-
-
-def _extract_exclude_dirs(patterns: Iterable[str]) -> frozenset[str]:
-    return frozenset(
-        pattern.rstrip("/") for pattern in patterns if _is_literal_dir_pattern(pattern)
-    )
+DEFAULT_EXCLUDE_DIRS: Final[frozenset[str]] = frozenset(
+    p.rstrip("/")
+    for p in DEFAULT_IGNORE_PATTERNS
+    if p.endswith("/") and not any(c in p for c in _WILDCARD_CHARS)
+)
 
 
-DEFAULT_EXCLUDE_DIRS: Final[frozenset[str]] = _extract_exclude_dirs(DEFAULT_IGNORE_PATTERNS)
+def read_ignore_file_lines(filepath: Path) -> tuple[str, ...]:
+    """Read raw ignore-file lines, returning an empty tuple when unreadable."""
+    try:
+        return tuple(filepath.read_text(encoding="utf-8").splitlines())
+    except (OSError, UnicodeDecodeError):
+        return ()
 
 
-def normalize_ignore_patterns(patterns: Iterable[str]) -> tuple[str, ...]:
-    """Drop empty patterns while preserving order."""
-    return tuple(pattern for pattern in patterns if pattern)
+def compile_ignore_spec(patterns: Iterable[str]) -> pathspec.PathSpec:
+    """Compile gitignore-style patterns into a reusable matcher."""
+    return pathspec.PathSpec.from_lines("gitwildmatch", patterns)
 
 
 def merge_ignore_patterns(
     base_patterns: Iterable[str],
     extra_patterns: Iterable[str],
 ) -> tuple[str, ...]:
-    """Append extra patterns onto a base pattern set."""
-    return tuple(base_patterns) + normalize_ignore_patterns(extra_patterns)
-
-
-def read_ignore_file_lines(filepath: Path) -> tuple[str, ...]:
-    """Read raw ignore-file lines, returning an empty tuple when unreadable."""
-    try:
-        ignore_text = filepath.read_text(encoding=TEXT_ENCODING)
-    except (OSError, UnicodeDecodeError):
-        return EMPTY_IGNORE_PATTERNS
-    return tuple(ignore_text.splitlines())
-
-
-def compile_ignore_spec(patterns: Iterable[str]) -> pathspec.PathSpec:
-    """Compile gitignore-style patterns into a reusable matcher."""
-    return pathspec.PathSpec.from_lines(GITIGNORE_STYLE, patterns)
+    """Append extra patterns onto a base pattern set, dropping blanks."""
+    return tuple(base_patterns) + tuple(p for p in extra_patterns if p)

--- a/tests/unit/configuration/test_ignore_patterns.py
+++ b/tests/unit/configuration/test_ignore_patterns.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from tunacode.configuration.ignore_patterns import (
     DEFAULT_IGNORE_PATTERNS,
-    EMPTY_IGNORE_PATTERNS,
     compile_ignore_spec,
     merge_ignore_patterns,
     read_ignore_file_lines,
@@ -30,11 +29,11 @@ def test_read_ignore_file_lines_returns_empty_tuple_for_invalid_utf8(tmp_path: P
     gitignore_path = tmp_path / ".gitignore"
     gitignore_path.write_bytes(b"\xff\xfeignored\n")
 
-    assert read_ignore_file_lines(gitignore_path) == EMPTY_IGNORE_PATTERNS
+    assert read_ignore_file_lines(gitignore_path) == ()
 
 
 def test_read_ignore_file_lines_returns_empty_tuple_for_directory(tmp_path: Path) -> None:
     gitignore_path = tmp_path / ".gitignore"
     gitignore_path.mkdir()
 
-    assert read_ignore_file_lines(gitignore_path) == EMPTY_IGNORE_PATTERNS
+    assert read_ignore_file_lines(gitignore_path) == ()

--- a/tests/unit/tools/test_ignore_manager.py
+++ b/tests/unit/tools/test_ignore_manager.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tunacode.configuration.ignore_patterns import EMPTY_IGNORE_PATTERNS
-
 from tunacode.tools.ignore_manager import read_gitignore_lines
 
 
@@ -13,4 +11,4 @@ def test_read_gitignore_lines_returns_empty_tuple_for_invalid_utf8(
     gitignore_path = tmp_path / ".gitignore"
     gitignore_path.write_bytes(b"\xff\xfeignored-dir/\n")
 
-    assert read_gitignore_lines(gitignore_path) == EMPTY_IGNORE_PATTERNS
+    assert read_gitignore_lines(gitignore_path) == ()


### PR DESCRIPTION
## Summary

- Remove unnecessary constants (`GITIGNORE_STYLE`, `TEXT_ENCODING`, `GIT_DIR_PATTERN`, `WILDCARD_CHARS`, `EMPTY_IGNORE_PATTERNS`) and inline them at point of use
- Remove unnecessary helper functions (`_is_literal_dir_pattern`, `_extract_exclude_dirs`, `normalize_ignore_patterns`) — their logic is now expressed inline or folded into existing functions
- Replace `EMPTY_IGNORE_PATTERNS` sentinel with plain `()` in both source and tests
- Compute `DEFAULT_EXCLUDE_DIRS` via inline comprehension instead of a dedicated extractor

## Test plan

- [ ] Existing unit tests pass (`test_ignore_patterns.py`, `test_ignore_manager.py`)
- [ ] Pre-commit hooks pass (ruff, bandit, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Refactoring: Simplify ignore_patterns module

This PR removes 5 constants and 3 helper functions to reduce indirection in the ignore patterns module, with notable changes to exception handling and type safety.

### Dead Code Removed
- **Module constants eliminated**: `GITIGNORE_STYLE`, `TEXT_ENCODING`, `GIT_DIR_PATTERN`, `WILDCARD_CHARS`, and sentinel `EMPTY_IGNORE_PATTERNS`
- **Helper functions eliminated**: `_is_literal_dir_pattern()`, `_extract_exclude_dirs()`, and `normalize_ignore_patterns()`
- All logic inlined at call sites; no external references to these removed items found elsewhere in the codebase

### Exception Handling Path Changes
- `read_ignore_file_lines()` now returns `()` (empty tuple literal) instead of `EMPTY_IGNORE_PATTERNS` sentinel on error
  - Maintains same error handling behavior (catches `OSError` and `UnicodeDecodeError`)
  - More explicit return value; eliminates reliance on sentinel constant for representing empty results
  - Tests updated to expect `()` instead of importing and checking against the deleted constant

### Type Safety Improvements
- **Sentinel elimination**: Replacing `EMPTY_IGNORE_PATTERNS` with plain `()` removes anti-pattern of sentinel-based result representation
  - Plain tuple literal is self-documenting and prevents accidental misuse of special constants
  - Aligns with Python conventions for representing "no data" (empty collections, not special markers)
- **Hardcoded values increase clarity**: Pattern style (`"gitwildmatch"`) and file encoding (`"utf-8"`) are now explicit at points of use, reducing indirection and improving code readability

### Code Simplification
- `DEFAULT_EXCLUDE_DIRS` computation moved from dedicated extractor function to inline frozenset comprehension
- `merge_ignore_patterns()` absorbs blank pattern filtering inline, removing separate `normalize_ignore_patterns()` call
- New internal `_WILDCARD_CHARS` constant used only for the inline `DEFAULT_EXCLUDE_DIRS` computation

### Testing Impact
All test files updated to expect `()` instead of `EMPTY_IGNORE_PATTERNS` with no changes to test logic:
- `test_ignore_patterns.py`: Updated invalid UTF-8 and directory path error assertions
- `test_ignore_manager.py`: Removed dependency on the deleted `EMPTY_IGNORE_PATTERNS` constant

**Net diff**: -40 lines, +18 lines (22-line reduction)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->