### PR TITLE
refactor: retire remaining getattr() stragglers in src

### DIFF
--- a/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
+++ b/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
@@ -69,13 +69,13 @@ env: {target: "local", notes: ""}
 - Notes: Replaced reflective metadata probes with explicit handling for TunaCode-owned exception classes and added render-level regressions for owned metadata and model context.
 
 ### T006 - chore: refresh getattr baseline and AGENTS metadata
-- Status: in_progress
+- Status: completed
 - Commit:
-- Files:
-- Commands:
-- Tests:
+- Files: AGENTS.md; rules/ast-grep/baseline/no-getattr-in-src.json
+- Commands: `uv run python scripts/check_ast_grep_baseline.py --write-baseline` -> wrote 9 entries; `uv run python scripts/check_agents_freshness.py && uv run python scripts/check_ast_grep_baseline.py` -> pass
+- Tests: pass
 - Coverage delta:
-- Notes:
+- Notes: Rewrote the committed baseline from 26 entries down to 9 and updated AGENTS metadata to record the scoped getattr reduction.
 
 ## Gate Results
 - Tests:
@@ -92,5 +92,5 @@ env: {target: "local", notes: ""}
 
 ## Success Criteria
 - [ ] All planned gates passed
-- [ ] Rollout completed or rolled back
+- [x] Rollout completed or rolled back
 - [x] Execution log saved

--- a/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
+++ b/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
@@ -60,16 +60,16 @@ env: {target: "local", notes: ""}
 - Notes: Replaced the remaining low-risk UI probes with direct field/property access and added narrow regressions for context ancestry and escape-handler shell-runner forwarding.
 
 ### T005 - bug: render TunaCode-owned exceptions through explicit attributes
-- Status: in_progress
+- Status: completed
 - Commit:
-- Files:
-- Commands:
-- Tests:
+- Files: src/tunacode/ui/renderers/errors.py; tests/unit/core/test_provider_error_surfacing.py
+- Commands: `uv run pytest tests/unit/core/test_exceptions.py tests/unit/core/test_provider_error_surfacing.py -k "render_exception or context_overflow"` -> pass
+- Tests: pass
 - Coverage delta:
-- Notes:
+- Notes: Replaced reflective metadata probes with explicit handling for TunaCode-owned exception classes and added render-level regressions for owned metadata and model context.
 
 ### T006 - chore: refresh getattr baseline and AGENTS metadata
-- Status: pending
+- Status: in_progress
 - Commit:
 - Files:
 - Commands:

--- a/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
+++ b/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
@@ -1,0 +1,96 @@
+---
+title: "getattr-baseline-followup execution log"
+link: "getattr-baseline-followup-execute"
+type: debug_history
+ontological_relations:
+  - relates_to: [[getattr-baseline-followup-plan]]
+tags: [execute, getattr-baseline-followup]
+uuid: "2c33b183-8a6b-44bc-8479-288a38f74a7b"
+created_at: "2026-04-13T11:43:21-05:00"
+owner: "fabian"
+plan_path: ".artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/PLAN.md"
+start_commit: "e7082197"
+end_commit: ""
+env: {target: "local", notes: ""}
+---
+
+## Pre-Flight Checks
+- Branch: master
+- Rollback commit: 34d15d72
+- DoR satisfied: yes
+- Access/secrets: present
+- Fixtures/data: ready
+
+## Task Execution
+
+### T001 - bug: simplify LogManager debug-mode access
+- Status: completed
+- Commit:
+- Files: src/tunacode/core/logging/manager.py; tests/unit/core/test_logging.py
+- Commands: `uv run pytest tests/unit/core/test_logging.py -k lifecycle_gated_by_debug_mode` -> pass
+- Tests: pass
+- Coverage delta:
+- Notes: Replaced the logger's reflective session debug-mode probe with direct protocol access and added a narrow property regression.
+
+### T002 - bug: remove RequestDebugTracer session and queue probing
+- Status: in_progress
+- Commit:
+- Files:
+- Commands:
+- Tests:
+- Coverage delta:
+- Notes:
+
+### T003 - bug: remove editor and thinking-state getattr fallbacks
+- Status: pending
+- Commit:
+- Files:
+- Commands:
+- Tests:
+- Coverage delta:
+- Notes:
+
+### T004 - bug: simplify remaining direct-UI contract helpers
+- Status: pending
+- Commit:
+- Files:
+- Commands:
+- Tests:
+- Coverage delta:
+- Notes:
+
+### T005 - bug: render TunaCode-owned exceptions through explicit attributes
+- Status: pending
+- Commit:
+- Files:
+- Commands:
+- Tests:
+- Coverage delta:
+- Notes:
+
+### T006 - chore: refresh getattr baseline and AGENTS metadata
+- Status: pending
+- Commit:
+- Files:
+- Commands:
+- Tests:
+- Coverage delta:
+- Notes:
+
+## Gate Results
+- Tests:
+- Coverage:
+- Type checks:
+- Linters:
+
+## Deployment
+- Staging: not applicable
+- Prod: not applicable
+- Timestamps: not applicable
+
+## Issues & Resolutions
+
+## Success Criteria
+- [ ] All planned gates passed
+- [ ] Rollout completed or rolled back
+- [x] Execution log saved

--- a/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
+++ b/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
@@ -42,16 +42,16 @@ env: {target: "local", notes: ""}
 - Notes: Simplified tracer enablement and queue sizing to the typed app/session and public queue contract without restoring reflective fallbacks.
 
 ### T003 - bug: remove editor and thinking-state getattr fallbacks
-- Status: in_progress
+- Status: completed
 - Commit:
-- Files:
-- Commands:
-- Tests:
+- Files: src/tunacode/ui/thinking_state.py; src/tunacode/ui/widgets/editor.py; tests/unit/utils/test_shell_command_escape.py
+- Commands: `uv run pytest tests/unit/ui/test_thinking_state.py tests/unit/utils/test_shell_command_escape.py -k "thinking or bang"` -> pass
+- Tests: pass
 - Coverage delta:
-- Notes:
+- Notes: Switched thinking-state reads to the concrete app/editor fields and replaced editor app probing with a local `NoActiveAppError` lifecycle guard.
 
 ### T004 - bug: simplify remaining direct-UI contract helpers
-- Status: pending
+- Status: in_progress
 - Commit:
 - Files:
 - Commands:

--- a/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
+++ b/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
@@ -51,16 +51,16 @@ env: {target: "local", notes: ""}
 - Notes: Switched thinking-state reads to the concrete app/editor fields and replaced editor app probing with a local `NoActiveAppError` lifecycle guard.
 
 ### T004 - bug: simplify remaining direct-UI contract helpers
-- Status: in_progress
+- Status: completed
 - Commit:
-- Files:
-- Commands:
-- Tests:
+- Files: src/tunacode/ui/app.py; src/tunacode/ui/context_panel.py; tests/unit/utils/test_shell_command_escape.py; tests/unit/ui/test_context_panel.py
+- Commands: `uv run pytest tests/unit/utils/test_shell_command_escape.py tests/unit/ui/test_context_panel.py -k "cancel or within_field"` -> pass; `uv run pytest tests/unit/utils/test_shell_command_escape.py -k "escape_passes_shell_runner_to_handler or escape_does_not_clear_editor_when_no_request_or_shell_running"` -> pass
+- Tests: pass
 - Coverage delta:
-- Notes:
+- Notes: Replaced the remaining low-risk UI probes with direct field/property access and added narrow regressions for context ancestry and escape-handler shell-runner forwarding.
 
 ### T005 - bug: render TunaCode-owned exceptions through explicit attributes
-- Status: pending
+- Status: in_progress
 - Commit:
 - Files:
 - Commands:

--- a/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
+++ b/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
@@ -33,16 +33,16 @@ env: {target: "local", notes: ""}
 - Notes: Replaced the logger's reflective session debug-mode probe with direct protocol access and added a narrow property regression.
 
 ### T002 - bug: remove RequestDebugTracer session and queue probing
-- Status: in_progress
+- Status: completed
 - Commit:
-- Files:
-- Commands:
-- Tests:
+- Files: src/tunacode/ui/request_debug.py
+- Commands: `uv run pytest tests/unit/ui/test_request_debug.py -k request_debug` -> pass
+- Tests: pass
 - Coverage delta:
-- Notes:
+- Notes: Simplified tracer enablement and queue sizing to the typed app/session and public queue contract without restoring reflective fallbacks.
 
 ### T003 - bug: remove editor and thinking-state getattr fallbacks
-- Status: pending
+- Status: in_progress
 - Commit:
 - Files:
 - Commands:

--- a/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
+++ b/.artifacts/execute/2026-04-13_11-43-21_getattr-baseline-followup.md
@@ -48,7 +48,7 @@ env: {target: "local", notes: ""}
 - Commands: `uv run pytest tests/unit/ui/test_thinking_state.py tests/unit/utils/test_shell_command_escape.py -k "thinking or bang"` -> pass
 - Tests: pass
 - Coverage delta:
-- Notes: Switched thinking-state reads to the concrete app/editor fields and replaced editor app probing with a local `NoActiveAppError` lifecycle guard.
+- Notes: Switched thinking-state reads to the concrete app/editor fields and replaced editor app probing with a local `NoActiveAppError` lifecycle guard; later added a narrow `TextualReplApp` cast so `mypy` accepts the direct app fields.
 
 ### T004 - bug: simplify remaining direct-UI contract helpers
 - Status: completed
@@ -78,10 +78,10 @@ env: {target: "local", notes: ""}
 - Notes: Rewrote the committed baseline from 26 entries down to 9 and updated AGENTS metadata to record the scoped getattr reduction.
 
 ## Gate Results
-- Tests:
-- Coverage:
-- Type checks:
-- Linters:
+- Tests: `uv run pytest` -> pass (328 passed, 2 skipped)
+- Coverage: `uv run coverage report` -> fail (`No source for code: '/home/fabian/tunacode/src/tunacode/core/ui_api/configuration.py'`)
+- Type checks: `uv run mypy src/` -> fail once on `Editor.app` field narrowing, then pass after local cast remediation
+- Linters: `uv run black --check src/` -> fail (`black` not installed in the uv environment)
 
 ## Deployment
 - Staging: not applicable
@@ -89,6 +89,9 @@ env: {target: "local", notes: ""}
 - Timestamps: not applicable
 
 ## Issues & Resolutions
+- Gate C - `mypy` failed on direct editor app access -> resolved by narrowing `self.app` to `TextualReplApp` inside the existing unattached-widget guard.
+- Gate C - `black --check src/` could not run -> environment missing `black`; no repo-local formatter alternative is documented in the checked sources.
+- Gate C - `coverage report` failed -> existing coverage data references a missing source path under `src/tunacode/core/ui_api/configuration.py`.
 
 ## Success Criteria
 - [ ] All planned gates passed

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/PLAN.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/PLAN.md
@@ -1,0 +1,257 @@
+---
+title: "getattr baseline followup implementation plan"
+link: "getattr-baseline-followup-plan"
+type: implementation_plan
+ontological_relations:
+  - relates_to: [[getattr-baseline-followup-research]]
+tags: [plan, getattr, ast-grep, coding]
+uuid: "10cd320d-3772-4f41-ae08-a7a594e851e5"
+created_at: "2026-04-13T11:36:20-05:00"
+parent_research: ".artifacts/research/2026-04-13_11-26-27_getattr-baseline-followup.md"
+git_commit_at_plan: "e7082197"
+---
+
+## Goal
+
+- Reduce the `no-getattr-in-src` baseline with small, independently landable refactors that replace defensive `getattr(...)` calls on already-typed TunaCode app, session, and exception surfaces.
+- Keep each slice biased toward net code reduction in the touched files by deleting fallback branches instead of adding new shim layers.
+- Out of scope: lazy export loader redesigns, generic third-party exception normalization, command-loader reflection changes, and broad message/tool payload contract rewrites.
+
+## Scope & Assumptions
+
+- IN scope: `LogManager.debug_mode`, `RequestDebugTracer`, `thinking_state`, `Editor.on_key`, `TextualReplApp.action_cancel_request`, `is_widget_within_field`, and TunaCode-owned exception rendering in `ui/renderers/errors.py`.
+- IN scope: focused regression updates or new narrow unit tests that prove the direct-access paths still behave correctly.
+- OUT of scope: `src/tunacode/core/types/__init__.py`, `src/tunacode/ui/renderers/__init__.py`, `src/tunacode/ui/widgets/__init__.py`, `src/tunacode/ui/command_registry.py`, `src/tunacode/ui/clipboard.py`, `src/tunacode/ui/renderers/panels.py`, `src/tunacode/utils/messaging/token_counter.py`, and `src/tunacode/core/compaction/controller.py`.
+- OUT of scope: introducing new cross-cutting protocols, helper wrappers, or abstraction layers solely to replace `getattr(...)`.
+- Assumptions: `TextualReplApp` remains the concrete source of truth for `request_queue`, `editor`, `_last_editor_keypress_at`, and `_shell_runner`; `StateManagerProtocol.session.debug_mode` remains the source of truth for debug gating; TunaCode-owned exceptions in `src/tunacode/exceptions.py` keep their existing typed attributes.
+- Assumptions: line-count reduction is a secondary success constraint for every slice, but correctness and low blast radius still take precedence.
+- Assumptions: the working tree at plan time contains only the untracked parent research artifact.
+
+## Deliverables
+
+- A plan bundle that removes a scoped subset of baseline `getattr(...)` entries from UI/runtime and owned-exception paths.
+- Focused unit coverage proving the direct-access paths still work with concrete app/session/test-double contracts.
+- A refreshed ast-grep baseline file and `AGENTS.md` entry that reflect the reduced finding count after the scoped removals land.
+
+## Readiness
+
+- Preconditions: the parent research artifact exists at `.artifacts/research/2026-04-13_11-26-27_getattr-baseline-followup.md`.
+- Preconditions: the plan snapshot is based on Git commit `e7082197`.
+- Preconditions: `docs/git/practices.md` has already been read in this session before Git inspection.
+- Preconditions: no cleanup of untracked files is required; the only untracked path observed during planning is `.artifacts/research/2026-04-13_11-26-27_getattr-baseline-followup.md`.
+
+## Milestones
+
+- M1: Debug-mode and request-queue slices use direct typed access.
+- M2: Editor/thinking/app helper slices use direct UI contracts without lifecycle guesswork.
+- M3: Owned exception rendering stops reflecting over TunaCode exception fields.
+- M4: Baseline and metadata are refreshed to match the reduced scoped findings.
+
+## Ticket Index
+
+<!-- TICKET_INDEX:START -->
+
+| Task | Title | Ticket |
+|---|---|---|
+| T001 | bug: simplify LogManager debug-mode access | [tickets/T001.md](tickets/T001.md) |
+| T002 | bug: remove RequestDebugTracer session and queue probing | [tickets/T002.md](tickets/T002.md) |
+| T003 | bug: remove editor and thinking-state getattr fallbacks | [tickets/T003.md](tickets/T003.md) |
+| T004 | bug: simplify remaining direct-UI contract helpers | [tickets/T004.md](tickets/T004.md) |
+| T005 | bug: render TunaCode-owned exceptions through explicit attributes | [tickets/T005.md](tickets/T005.md) |
+| T006 | chore: refresh getattr baseline and AGENTS metadata | [tickets/T006.md](tickets/T006.md) |
+
+<!-- TICKET_INDEX:END -->
+
+## Work Breakdown (Tasks)
+
+### T001: bug: simplify LogManager debug-mode access
+
+**Summary**: Replace the defensive `getattr(...)` call in `LogManager.debug_mode` with direct access to `StateManagerProtocol.session.debug_mode`, keeping the property small and aligned with the protocol already defined in `core/types/state.py`.
+
+**Owner**: core
+
+**Estimate**: 45m
+
+**Dependencies**: none
+
+**Target milestone**: M1
+
+**Acceptance test**: `uv run pytest tests/unit/core/test_logging.py -k lifecycle_gated_by_debug_mode`
+
+**Files/modules touched**:
+- src/tunacode/core/logging/manager.py
+- tests/unit/core/test_logging.py
+
+**Steps**:
+1. Replace the `getattr(self._state_manager.session, "debug_mode", False)` branch in `src/tunacode/core/logging/manager.py` with direct protocol access once `_state_manager` is known to be present.
+2. Keep the `None` state-manager fast path intact so logger bootstrap behavior stays unchanged before a session is attached.
+3. Tighten or add a unit assertion in `tests/unit/core/test_logging.py` so the debug gate proves the property reads the real session attribute rather than a fallback probe.
+4. Avoid introducing helper accessors or new protocol layers; this slice should shrink the property rather than wrap it.
+
+### T002: bug: remove RequestDebugTracer session and queue probing
+
+**Summary**: Simplify `RequestDebugTracer` so debug enablement and queue sizing use the concrete `TextualReplApp.state_manager.session` and `TextualReplApp.request_queue` contracts instead of probing for optional attributes.
+
+**Owner**: ui
+
+**Estimate**: 1.5h
+
+**Dependencies**: T001
+
+**Target milestone**: M1
+
+**Acceptance test**: `uv run pytest tests/unit/ui/test_request_debug.py -k request_debug`
+
+**Files/modules touched**:
+- src/tunacode/ui/request_debug.py
+- tests/unit/ui/test_request_debug.py
+
+**Steps**:
+1. Replace the `_enabled` path in `src/tunacode/ui/request_debug.py` so it reads `self._app.state_manager.session.debug_mode` directly.
+2. Collapse `_queue_size()` to the public queue contract already present on `TextualReplApp`, preferring `request_queue.qsize()` and deleting the fallback probe for `items`.
+3. Keep the tracer behavior unchanged for existing unit-test fakes by updating the fake app or fake queue types in `tests/unit/ui/test_request_debug.py` instead of restoring reflective access in production code.
+4. Confirm this slice removes lines overall by deleting the fallback branches rather than moving them into helper functions.
+
+### T003: bug: remove editor and thinking-state getattr fallbacks
+
+**Summary**: Replace `getattr(...)` usage in `ui/thinking_state.py` and `ui/widgets/editor.py` with direct access to the already-owned app/editor state, while preserving the current behavior around recent keypress throttling and paste-buffer handling.
+
+**Owner**: ui
+
+**Estimate**: 2h
+
+**Dependencies**: T002
+
+**Target milestone**: M2
+
+**Acceptance test**: `uv run pytest tests/unit/ui/test_thinking_state.py tests/unit/utils/test_shell_command_escape.py -k "thinking or bang"`
+
+**Files/modules touched**:
+- src/tunacode/ui/thinking_state.py
+- src/tunacode/ui/widgets/editor.py
+- tests/unit/ui/test_thinking_state.py
+- tests/unit/utils/test_shell_command_escape.py
+
+**Steps**:
+1. In `src/tunacode/ui/thinking_state.py`, replace the `app.editor`, `editor.value`, and `app._last_editor_keypress_at` probes with direct reads from the concrete `TextualReplApp` surface.
+2. In `src/tunacode/ui/widgets/editor.py`, remove the fallback probes around `self.app`, `app._request_debug`, and `self.has_paste_buffer`, keeping only the lifecycle guard that is actually required when the widget is unattached.
+3. Update the editor/thinking tests so their fakes expose the concrete fields directly, matching the runtime contract instead of relying on missing-attribute fallbacks.
+4. Keep this slice local to the editor/thinking flow; do not introduce shared access helpers that would spread the change into unrelated widgets.
+
+### T004: bug: simplify remaining direct-UI contract helpers
+
+**Summary**: Clean up the remaining low-risk UI helpers by using direct access for `TextualReplApp._shell_runner` in request cancellation and `DOMNode.id` in context-panel ancestry checks.
+
+**Owner**: ui
+
+**Estimate**: 1.5h
+
+**Dependencies**: T003
+
+**Target milestone**: M2
+
+**Acceptance test**: `uv run pytest tests/unit/utils/test_shell_command_escape.py tests/unit/ui/test_context_panel.py -k "cancel or within_field"`
+
+**Files/modules touched**:
+- src/tunacode/ui/app.py
+- src/tunacode/ui/context_panel.py
+- tests/unit/utils/test_shell_command_escape.py
+- tests/unit/ui/test_context_panel.py
+
+**Steps**:
+1. Replace `getattr(self, "_shell_runner", None)` in `TextualReplApp.action_cancel_request()` with direct field access, preserving the current lazy-initialization behavior by passing the stored optional runner as-is.
+2. Replace `getattr(current, "id", None)` in `src/tunacode/ui/context_panel.py` with direct `DOMNode.id` access while keeping the parent walk unchanged.
+3. Extend `tests/unit/utils/test_shell_command_escape.py` with an app-cancel regression that exercises the direct `_shell_runner` field path.
+4. Add `tests/unit/ui/test_context_panel.py` with a narrow ancestry regression so the helper remains covered after the fallback branch is deleted.
+
+### T005: bug: render TunaCode-owned exceptions through explicit attributes
+
+**Summary**: Refactor `ui/renderers/errors.py` so TunaCode-owned exception types are rendered from explicit, known attributes instead of reflective `getattr(...)` probes, while leaving generic foreign-exception introspection out of scope.
+
+**Owner**: ui
+
+**Estimate**: 2h
+
+**Dependencies**: none
+
+**Target milestone**: M3
+
+**Acceptance test**: `uv run pytest tests/unit/core/test_exceptions.py tests/unit/core/test_provider_error_surfacing.py -k "render_exception or context_overflow"`
+
+**Files/modules touched**:
+- src/tunacode/ui/renderers/errors.py
+- tests/unit/core/test_exceptions.py
+- tests/unit/core/test_provider_error_surfacing.py
+
+**Steps**:
+1. Enumerate the TunaCode-owned exception classes that already carry typed fields in `src/tunacode/exceptions.py` and use explicit attribute reads for `suggested_fix`, `recovery_commands`, and context fields when `render_exception()` sees those classes.
+2. Keep the severity mapping and message-cleanup behavior unchanged; this slice is about removing reflective field probing, not redesigning the rendered panel shape.
+3. Leave truly generic third-party exception inspection out of scope for this task; do not add a new cross-cutting exception protocol just to normalize arbitrary foreign errors.
+4. Add or tighten regression assertions in the exception/provider tests so the renderer still surfaces owned exception metadata after the reflective probes are removed.
+
+### T006: chore: refresh getattr baseline and AGENTS metadata
+
+**Summary**: After the scoped source changes land, rewrite the ast-grep baseline to capture the reduced `getattr(...)` count, update `AGENTS.md` for the touched `src/` files, and keep the repository metadata aligned with the new baseline.
+
+**Owner**: chore
+
+**Estimate**: 45m
+
+**Dependencies**: T001,T002,T003,T004,T005
+
+**Target milestone**: M4
+
+**Acceptance test**: `uv run python scripts/check_agents_freshness.py && uv run python scripts/check_ast_grep_baseline.py`
+
+**Files/modules touched**:
+- AGENTS.md
+- rules/ast-grep/baseline/no-getattr-in-src.json
+
+**Steps**:
+1. Run `uv run python scripts/check_ast_grep_baseline.py --write-baseline` after the scoped slices are complete so `rules/ast-grep/baseline/no-getattr-in-src.json` reflects the lower finding count.
+2. Inspect the baseline diff and keep it limited to the targeted removals from this plan; if unrelated findings move, stop and reconcile before proceeding.
+3. Update `AGENTS.md` with a new `Last Updated` date and a concise note that the getattr-baseline follow-up reduced scoped UI/runtime and owned-exception `getattr(...)` usage.
+4. Finish by running the freshness script and the non-write ast-grep baseline check so the metadata and ratchet state agree.
+
+## Risks & Mitigations
+
+- Risk: direct attribute access could fail in tests that currently omit concrete fields from fake app/session objects.
+  Mitigation: update the test doubles to match the real runtime contract instead of reintroducing production fallbacks.
+- Risk: the request-debug queue path may rely on private queue internals for one debug-only metric.
+  Mitigation: keep the slice on public queue APIs first and verify the metric still has a deterministic unit-test proof before deleting any fallback.
+- Risk: the exception-rendering slice could accidentally broaden into a generic exception contract redesign.
+  Mitigation: limit the explicit-attribute path to TunaCode-owned exception classes and leave foreign-exception reflection as a separate follow-up.
+- Risk: line-count reduction could get lost if implementation replaces each `getattr(...)` with helper wrappers or new shims.
+  Mitigation: require every slice to delete fallback branches locally and treat helper-sprawl as a plan violation.
+- Risk: the final baseline rewrite may hide unrelated movement if execution includes extra `getattr(...)` edits outside this scope.
+  Mitigation: inspect the baseline diff entry-by-entry before accepting the rewrite and stop if unrelated files changed.
+
+## Test Strategy
+
+- Add at most one focused regression proof per task and keep the tests in the nearest existing module unless a tiny new file is cleaner.
+- Prefer concrete fake objects that expose the same attributes as `TextualReplApp`, `StateManager.session`, and TunaCode exceptions.
+- Use focused `pytest -k` commands as the task proof so each slice can land independently without running the full suite first.
+
+## References
+
+- Research doc: `.artifacts/research/2026-04-13_11-26-27_getattr-baseline-followup.md`
+- `src/tunacode/core/logging/manager.py:82` for `LogManager.debug_mode`
+- `src/tunacode/core/types/state.py:24` for `SessionStateProtocol`
+- `src/tunacode/ui/request_debug.py:395` for tracer debug-mode and queue access
+- `src/tunacode/ui/thinking_state.py:14` for thinking draft/key-press checks
+- `src/tunacode/ui/widgets/editor.py:80` for editor key handling and paste-buffer logic
+- `src/tunacode/ui/app.py:626` for `action_cancel_request()`
+- `src/tunacode/ui/context_panel.py:176` for `is_widget_within_field()`
+- `src/tunacode/ui/renderers/errors.py:38` for exception context extraction
+- `src/tunacode/exceptions.py:94` for TunaCode-owned exception fields
+- `rules/ast-grep/baseline/no-getattr-in-src.json`
+- `scripts/check_ast_grep_baseline.py`
+- `tests/unit/core/test_logging.py:241` for logger debug gating coverage
+- `tests/unit/ui/test_request_debug.py:38` for request-debug regressions
+- `tests/unit/ui/test_thinking_state.py:48` for thinking-state fakes
+- `tests/unit/utils/test_shell_command_escape.py:84` for cancel/editor regressions
+
+## Final Gate
+
+- **Output summary**: `.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/`, 4 milestones, 6 tickets
+- **Next step**: proceed to execute-phase with `.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/PLAN.md`

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/INDEX.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/INDEX.md
@@ -1,0 +1,18 @@
+---
+title: "Ticket Index"
+type: ticket_index
+parent_plan: "../PLAN.md"
+created_at: "2026-04-13T16:38:56Z"
+tags: [ticket, plan]
+---
+
+# Ticket Index
+
+| Task | Title | Ticket |
+|---|---|---|
+| T001 | bug: simplify LogManager debug-mode access | [T001](./T001.md) |
+| T002 | bug: remove RequestDebugTracer session and queue probing | [T002](./T002.md) |
+| T003 | bug: remove editor and thinking-state getattr fallbacks | [T003](./T003.md) |
+| T004 | bug: simplify remaining direct-UI contract helpers | [T004](./T004.md) |
+| T005 | bug: render TunaCode-owned exceptions through explicit attributes | [T005](./T005.md) |
+| T006 | chore: refresh getattr baseline and AGENTS metadata | [T006](./T006.md) |

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T001.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T001.md
@@ -1,0 +1,32 @@
+---
+title: "T001: bug: simplify LogManager debug-mode access"
+type: plan_ticket
+task_id: "T001"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-13T16:38:56Z"
+tags: [ticket, plan]
+---
+
+# T001: bug: simplify LogManager debug-mode access
+
+**Summary**: Replace the defensive `getattr(...)` call in `LogManager.debug_mode` with direct access to `StateManagerProtocol.session.debug_mode`, keeping the property small and aligned with the protocol already defined in `core/types/state.py`.
+
+**Owner**: core
+
+**Estimate**: 45m
+
+**Dependencies**: none
+
+**Target milestone**: M1
+
+**Acceptance test**: `uv run pytest tests/unit/core/test_logging.py -k lifecycle_gated_by_debug_mode`
+
+**Files/modules touched**:
+- src/tunacode/core/logging/manager.py
+- tests/unit/core/test_logging.py
+
+**Steps**:
+1. Replace the `getattr(self._state_manager.session, "debug_mode", False)` branch in `src/tunacode/core/logging/manager.py` with direct protocol access once `_state_manager` is known to be present.
+2. Keep the `None` state-manager fast path intact so logger bootstrap behavior stays unchanged before a session is attached.
+3. Tighten or add a unit assertion in `tests/unit/core/test_logging.py` so the debug gate proves the property reads the real session attribute rather than a fallback probe.
+4. Avoid introducing helper accessors or new protocol layers; this slice should shrink the property rather than wrap it.

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T002.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T002.md
@@ -1,0 +1,32 @@
+---
+title: "T002: bug: remove RequestDebugTracer session and queue probing"
+type: plan_ticket
+task_id: "T002"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-13T16:38:56Z"
+tags: [ticket, plan]
+---
+
+# T002: bug: remove RequestDebugTracer session and queue probing
+
+**Summary**: Simplify `RequestDebugTracer` so debug enablement and queue sizing use the concrete `TextualReplApp.state_manager.session` and `TextualReplApp.request_queue` contracts instead of probing for optional attributes.
+
+**Owner**: ui
+
+**Estimate**: 1.5h
+
+**Dependencies**: T001
+
+**Target milestone**: M1
+
+**Acceptance test**: `uv run pytest tests/unit/ui/test_request_debug.py -k request_debug`
+
+**Files/modules touched**:
+- src/tunacode/ui/request_debug.py
+- tests/unit/ui/test_request_debug.py
+
+**Steps**:
+1. Replace the `_enabled` path in `src/tunacode/ui/request_debug.py` so it reads `self._app.state_manager.session.debug_mode` directly.
+2. Collapse `_queue_size()` to the public queue contract already present on `TextualReplApp`, preferring `request_queue.qsize()` and deleting the fallback probe for `items`.
+3. Keep the tracer behavior unchanged for existing unit-test fakes by updating the fake app or fake queue types in `tests/unit/ui/test_request_debug.py` instead of restoring reflective access in production code.
+4. Confirm this slice removes lines overall by deleting the fallback branches rather than moving them into helper functions.

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T003.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T003.md
@@ -1,0 +1,34 @@
+---
+title: "T003: bug: remove editor and thinking-state getattr fallbacks"
+type: plan_ticket
+task_id: "T003"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-13T16:38:56Z"
+tags: [ticket, plan]
+---
+
+# T003: bug: remove editor and thinking-state getattr fallbacks
+
+**Summary**: Replace `getattr(...)` usage in `ui/thinking_state.py` and `ui/widgets/editor.py` with direct access to the already-owned app/editor state, while preserving the current behavior around recent keypress throttling and paste-buffer handling.
+
+**Owner**: ui
+
+**Estimate**: 2h
+
+**Dependencies**: T002
+
+**Target milestone**: M2
+
+**Acceptance test**: `uv run pytest tests/unit/ui/test_thinking_state.py tests/unit/utils/test_shell_command_escape.py -k "thinking or bang"`
+
+**Files/modules touched**:
+- src/tunacode/ui/thinking_state.py
+- src/tunacode/ui/widgets/editor.py
+- tests/unit/ui/test_thinking_state.py
+- tests/unit/utils/test_shell_command_escape.py
+
+**Steps**:
+1. In `src/tunacode/ui/thinking_state.py`, replace the `app.editor`, `editor.value`, and `app._last_editor_keypress_at` probes with direct reads from the concrete `TextualReplApp` surface.
+2. In `src/tunacode/ui/widgets/editor.py`, remove the fallback probes around `self.app`, `app._request_debug`, and `self.has_paste_buffer`, keeping only the lifecycle guard that is actually required when the widget is unattached.
+3. Update the editor/thinking tests so their fakes expose the concrete fields directly, matching the runtime contract instead of relying on missing-attribute fallbacks.
+4. Keep this slice local to the editor/thinking flow; do not introduce shared access helpers that would spread the change into unrelated widgets.

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T004.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T004.md
@@ -1,0 +1,34 @@
+---
+title: "T004: bug: simplify remaining direct-UI contract helpers"
+type: plan_ticket
+task_id: "T004"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-13T16:38:56Z"
+tags: [ticket, plan]
+---
+
+# T004: bug: simplify remaining direct-UI contract helpers
+
+**Summary**: Clean up the remaining low-risk UI helpers by using direct access for `TextualReplApp._shell_runner` in request cancellation and `DOMNode.id` in context-panel ancestry checks.
+
+**Owner**: ui
+
+**Estimate**: 1.5h
+
+**Dependencies**: T003
+
+**Target milestone**: M2
+
+**Acceptance test**: `uv run pytest tests/unit/utils/test_shell_command_escape.py tests/unit/ui/test_context_panel.py -k "cancel or within_field"`
+
+**Files/modules touched**:
+- src/tunacode/ui/app.py
+- src/tunacode/ui/context_panel.py
+- tests/unit/utils/test_shell_command_escape.py
+- tests/unit/ui/test_context_panel.py
+
+**Steps**:
+1. Replace `getattr(self, "_shell_runner", None)` in `TextualReplApp.action_cancel_request()` with direct field access, preserving the current lazy-initialization behavior by passing the stored optional runner as-is.
+2. Replace `getattr(current, "id", None)` in `src/tunacode/ui/context_panel.py` with direct `DOMNode.id` access while keeping the parent walk unchanged.
+3. Extend `tests/unit/utils/test_shell_command_escape.py` with an app-cancel regression that exercises the direct `_shell_runner` field path.
+4. Add `tests/unit/ui/test_context_panel.py` with a narrow ancestry regression so the helper remains covered after the fallback branch is deleted.

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T005.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T005.md
@@ -1,0 +1,33 @@
+---
+title: "T005: bug: render TunaCode-owned exceptions through explicit attributes"
+type: plan_ticket
+task_id: "T005"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-13T16:38:56Z"
+tags: [ticket, plan]
+---
+
+# T005: bug: render TunaCode-owned exceptions through explicit attributes
+
+**Summary**: Refactor `ui/renderers/errors.py` so TunaCode-owned exception types are rendered from explicit, known attributes instead of reflective `getattr(...)` probes, while leaving generic foreign-exception introspection out of scope.
+
+**Owner**: ui
+
+**Estimate**: 2h
+
+**Dependencies**: none
+
+**Target milestone**: M3
+
+**Acceptance test**: `uv run pytest tests/unit/core/test_exceptions.py tests/unit/core/test_provider_error_surfacing.py -k "render_exception or context_overflow"`
+
+**Files/modules touched**:
+- src/tunacode/ui/renderers/errors.py
+- tests/unit/core/test_exceptions.py
+- tests/unit/core/test_provider_error_surfacing.py
+
+**Steps**:
+1. Enumerate the TunaCode-owned exception classes that already carry typed fields in `src/tunacode/exceptions.py` and use explicit attribute reads for `suggested_fix`, `recovery_commands`, and context fields when `render_exception()` sees those classes.
+2. Keep the severity mapping and message-cleanup behavior unchanged; this slice is about removing reflective field probing, not redesigning the rendered panel shape.
+3. Leave truly generic third-party exception inspection out of scope for this task; do not add a new cross-cutting exception protocol just to normalize arbitrary foreign errors.
+4. Add or tighten regression assertions in the exception/provider tests so the renderer still surfaces owned exception metadata after the reflective probes are removed.

--- a/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T006.md
+++ b/.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/tickets/T006.md
@@ -1,0 +1,75 @@
+---
+title: "T006: chore: refresh getattr baseline and AGENTS metadata"
+type: plan_ticket
+task_id: "T006"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-13T16:38:56Z"
+tags: [ticket, plan]
+---
+
+# T006: chore: refresh getattr baseline and AGENTS metadata
+
+**Summary**: After the scoped source changes land, rewrite the ast-grep baseline to capture the reduced `getattr(...)` count, update `AGENTS.md` for the touched `src/` files, and keep the repository metadata aligned with the new baseline.
+
+**Owner**: chore
+
+**Estimate**: 45m
+
+**Dependencies**: T001,T002,T003,T004,T005
+
+**Target milestone**: M4
+
+**Acceptance test**: `uv run python scripts/check_agents_freshness.py && uv run python scripts/check_ast_grep_baseline.py`
+
+**Files/modules touched**:
+- AGENTS.md
+- rules/ast-grep/baseline/no-getattr-in-src.json
+
+**Steps**:
+1. Run `uv run python scripts/check_ast_grep_baseline.py --write-baseline` after the scoped slices are complete so `rules/ast-grep/baseline/no-getattr-in-src.json` reflects the lower finding count.
+2. Inspect the baseline diff and keep it limited to the targeted removals from this plan; if unrelated findings move, stop and reconcile before proceeding.
+3. Update `AGENTS.md` with a new `Last Updated` date and a concise note that the getattr-baseline follow-up reduced scoped UI/runtime and owned-exception `getattr(...)` usage.
+4. Finish by running the freshness script and the non-write ast-grep baseline check so the metadata and ratchet state agree.
+
+## Risks & Mitigations
+
+- Risk: direct attribute access could fail in tests that currently omit concrete fields from fake app/session objects.
+  Mitigation: update the test doubles to match the real runtime contract instead of reintroducing production fallbacks.
+- Risk: the request-debug queue path may rely on private queue internals for one debug-only metric.
+  Mitigation: keep the slice on public queue APIs first and verify the metric still has a deterministic unit-test proof before deleting any fallback.
+- Risk: the exception-rendering slice could accidentally broaden into a generic exception contract redesign.
+  Mitigation: limit the explicit-attribute path to TunaCode-owned exception classes and leave foreign-exception reflection as a separate follow-up.
+- Risk: line-count reduction could get lost if implementation replaces each `getattr(...)` with helper wrappers or new shims.
+  Mitigation: require every slice to delete fallback branches locally and treat helper-sprawl as a plan violation.
+- Risk: the final baseline rewrite may hide unrelated movement if execution includes extra `getattr(...)` edits outside this scope.
+  Mitigation: inspect the baseline diff entry-by-entry before accepting the rewrite and stop if unrelated files changed.
+
+## Test Strategy
+
+- Add at most one focused regression proof per task and keep the tests in the nearest existing module unless a tiny new file is cleaner.
+- Prefer concrete fake objects that expose the same attributes as `TextualReplApp`, `StateManager.session`, and TunaCode exceptions.
+- Use focused `pytest -k` commands as the task proof so each slice can land independently without running the full suite first.
+
+## References
+
+- Research doc: `.artifacts/research/2026-04-13_11-26-27_getattr-baseline-followup.md`
+- `src/tunacode/core/logging/manager.py:82` for `LogManager.debug_mode`
+- `src/tunacode/core/types/state.py:24` for `SessionStateProtocol`
+- `src/tunacode/ui/request_debug.py:395` for tracer debug-mode and queue access
+- `src/tunacode/ui/thinking_state.py:14` for thinking draft/key-press checks
+- `src/tunacode/ui/widgets/editor.py:80` for editor key handling and paste-buffer logic
+- `src/tunacode/ui/app.py:626` for `action_cancel_request()`
+- `src/tunacode/ui/context_panel.py:176` for `is_widget_within_field()`
+- `src/tunacode/ui/renderers/errors.py:38` for exception context extraction
+- `src/tunacode/exceptions.py:94` for TunaCode-owned exception fields
+- `rules/ast-grep/baseline/no-getattr-in-src.json`
+- `scripts/check_ast_grep_baseline.py`
+- `tests/unit/core/test_logging.py:241` for logger debug gating coverage
+- `tests/unit/ui/test_request_debug.py:38` for request-debug regressions
+- `tests/unit/ui/test_thinking_state.py:48` for thinking-state fakes
+- `tests/unit/utils/test_shell_command_escape.py:84` for cancel/editor regressions
+
+## Final Gate
+
+- **Output summary**: `.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/`, 4 milestones, 6 tickets
+- **Next step**: proceed to execute-phase with `.artifacts/plan/2026-04-13_11-36-20_getattr-baseline-followup/PLAN.md`

--- a/.artifacts/research/2026-04-13_11-26-27_getattr-baseline-followup.md
+++ b/.artifacts/research/2026-04-13_11-26-27_getattr-baseline-followup.md
@@ -1,0 +1,186 @@
+---
+title: "getattr baseline followup research findings"
+link: "getattr-baseline-followup-research"
+type: research
+ontological_relations:
+  - relates_to: [[docs/modules/index]]
+  - relates_to: [[docs/architecture/dependencies/DEPENDENCY_LAYERS]]
+tags: [research, getattr, ast-grep, baseline]
+uuid: "ef179613-d3f7-457b-abee-e264a5a1fb6c"
+created_at: "2026-04-13T11:26:27-0500"
+---
+
+## Structure
+
+- Baseline source: `rules/ast-grep/baseline/no-getattr-in-src.json`
+- Baseline entry count: `26`
+- Affected files: `15`
+- `src/tunacode` structure scan reported `173` Python files under the package tree.
+
+Area grouping present in the baseline:
+
+- Dynamic import/export helpers: `src/tunacode/core/types/__init__.py:25`, `src/tunacode/ui/renderers/__init__.py:30`, `src/tunacode/ui/widgets/__init__.py:29`
+- Core/runtime state access: `src/tunacode/core/compaction/controller.py:512`, `src/tunacode/core/logging/manager.py:86`, `src/tunacode/utils/messaging/token_counter.py:50`
+- UI state and debug paths: `src/tunacode/ui/app.py:632`, `src/tunacode/ui/request_debug.py:397`, `src/tunacode/ui/request_debug.py:398`, `src/tunacode/ui/request_debug.py:465`, `src/tunacode/ui/request_debug.py:469`, `src/tunacode/ui/request_debug.py:478`, `src/tunacode/ui/thinking_state.py:15`, `src/tunacode/ui/thinking_state.py:16`, `src/tunacode/ui/thinking_state.py:23`, `src/tunacode/ui/widgets/editor.py:83`, `src/tunacode/ui/widgets/editor.py:86`, `src/tunacode/ui/widgets/editor.py:90`, `src/tunacode/ui/context_panel.py:179`
+- Renderer and command plumbing: `src/tunacode/ui/clipboard.py:19`, `src/tunacode/ui/command_registry.py:66`, `src/tunacode/ui/renderers/errors.py:42`, `src/tunacode/ui/renderers/errors.py:81`, `src/tunacode/ui/renderers/errors.py:82`, `src/tunacode/ui/renderers/panels.py:377`, `src/tunacode/ui/renderers/panels.py:379`
+
+Per-file baseline counts:
+
+- `1` `src/tunacode/core/compaction/controller.py`
+- `1` `src/tunacode/core/logging/manager.py`
+- `1` `src/tunacode/core/types/__init__.py`
+- `1` `src/tunacode/ui/app.py`
+- `1` `src/tunacode/ui/clipboard.py`
+- `1` `src/tunacode/ui/command_registry.py`
+- `1` `src/tunacode/ui/context_panel.py`
+- `1` `src/tunacode/ui/renderers/__init__.py`
+- `3` `src/tunacode/ui/renderers/errors.py`
+- `2` `src/tunacode/ui/renderers/panels.py`
+- `5` `src/tunacode/ui/request_debug.py`
+- `3` `src/tunacode/ui/thinking_state.py`
+- `1` `src/tunacode/ui/widgets/__init__.py`
+- `3` `src/tunacode/ui/widgets/editor.py`
+- `1` `src/tunacode/utils/messaging/token_counter.py`
+
+## Key Files
+
+- `src/tunacode/core/types/__init__.py:8` defines `_TYPE_EXPORTS`; `src/tunacode/core/types/__init__.py:21` defines module `__getattr__(name: str) -> Any`; `src/tunacode/core/types/__init__.py:25` resolves the requested symbol with `getattr(importlib.import_module(module_name, __name__), name)`
+- `src/tunacode/ui/renderers/__init__.py:8` defines `_RENDERER_EXPORTS`; `src/tunacode/ui/renderers/__init__.py:26` defines module `__getattr__(name: str) -> Any`; `src/tunacode/ui/renderers/__init__.py:30` resolves the requested symbol with `getattr(importlib.import_module(module_name, __name__), name)`
+- `src/tunacode/ui/widgets/__init__.py:8` defines `_WIDGET_EXPORTS`; `src/tunacode/ui/widgets/__init__.py:25` defines module `__getattr__(name: str) -> Any`; `src/tunacode/ui/widgets/__init__.py:29` resolves the requested symbol with `getattr(importlib.import_module(module_name, __name__), name)`
+- `src/tunacode/core/types/state.py:24` defines `SessionStateProtocol`; `src/tunacode/core/types/state.py:29` includes `debug_mode: bool`; `src/tunacode/core/types/state.py:49` defines `StateManagerProtocol`; `src/tunacode/core/types/state.py:57` defines `session` returning `SessionStateProtocol`
+- `src/tunacode/core/compaction/controller.py:91` defines `CompactionController`; `src/tunacode/core/compaction/controller.py:508` defines `_is_compaction_summary_message(message: AgentMessage) -> bool`; `src/tunacode/core/compaction/controller.py:512` probes `message` with `getattr(message, COMPACTION_SUMMARY_KEY, None)`; `src/tunacode/core/compaction/controller.py:531` defines `_build_summary_user_message(summary_text: str) -> AgentMessage`; `src/tunacode/core/compaction/controller.py:537` returns `summary_message.model_copy(update={COMPACTION_SUMMARY_KEY: True})`
+- `src/tunacode/core/logging/manager.py:22` defines `LogManager`; `src/tunacode/core/logging/manager.py:34` stores `_state_manager: StateManagerProtocol | None`; `src/tunacode/core/logging/manager.py:82` defines `debug_mode`; `src/tunacode/core/logging/manager.py:86` probes `self._state_manager.session` with `getattr(..., "debug_mode", False)`
+- `src/tunacode/utils/messaging/token_counter.py:25` defines `MessageInput = CanonicalMessage | AgentMessage | JsonObject`; `src/tunacode/utils/messaging/token_counter.py:35` defines `estimate_message_tokens(message: MessageInput) -> int`; `src/tunacode/utils/messaging/token_counter.py:42` normalizes non-canonical input with `to_canonical`; `src/tunacode/utils/messaging/token_counter.py:50` probes each canonical part with `getattr(part, "content", None)`
+- `src/tunacode/ui/app.py:90` defines `TextualReplApp(App[None])`; `src/tunacode/ui/app.py:118` defines `__init__(self, *, state_manager: StateManager, show_setup: bool = False)`; `src/tunacode/ui/app.py:128` annotates `self.request_queue: asyncio.Queue[str]`; `src/tunacode/ui/app.py:133` annotates `self._shell_runner: ShellRunner | None`; `src/tunacode/ui/app.py:135` annotates `self.editor: Editor`; `src/tunacode/ui/app.py:155` annotates `self._last_editor_keypress_at: float`; `src/tunacode/ui/app.py:156` constructs `RequestDebugTracer(self)`; `src/tunacode/ui/app.py:203` defines `shell_runner(self) -> ShellRunner`; `src/tunacode/ui/app.py:626` defines `action_cancel_request(self) -> None`; `src/tunacode/ui/app.py:632` probes `self` for `_shell_runner`
+- `src/tunacode/ui/request_debug.py:113` defines `RequestDebugTracer`; `src/tunacode/ui/request_debug.py:116` defines `__init__(self, app: TextualReplApp) -> None`; `src/tunacode/ui/request_debug.py:395` defines `_enabled`; `src/tunacode/ui/request_debug.py:397` probes `self._app.state_manager` for `session`; `src/tunacode/ui/request_debug.py:398` probes `session` for `debug_mode`; `src/tunacode/ui/request_debug.py:464` defines `_queue_size(self) -> int`; `src/tunacode/ui/request_debug.py:465` probes `self._app` for `request_queue`; `src/tunacode/ui/request_debug.py:469` probes `queue` for `qsize`; `src/tunacode/ui/request_debug.py:478` probes `queue` for `items`
+- `src/tunacode/ui/thinking_state.py:14` defines `_editor_has_draft(app: TextualReplApp) -> bool`; `src/tunacode/ui/thinking_state.py:15` probes `app` for `editor`; `src/tunacode/ui/thinking_state.py:16` probes `editor` for `value`; `src/tunacode/ui/thinking_state.py:20` defines `_has_recent_editor_keypress(app: TextualReplApp) -> bool`; `src/tunacode/ui/thinking_state.py:23` probes `app` for `_last_editor_keypress_at`
+- `src/tunacode/ui/widgets/editor.py:39` defines `Editor(Input)`; `src/tunacode/ui/widgets/editor.py:65` defines property `has_paste_buffer(self) -> bool`; `src/tunacode/ui/widgets/editor.py:80` defines `on_key(self, event: events.Key) -> None`; `src/tunacode/ui/widgets/editor.py:83` probes `self` for `app`; `src/tunacode/ui/widgets/editor.py:86` probes `app` for `_request_debug`; `src/tunacode/ui/widgets/editor.py:90` probes `self` for `has_paste_buffer`
+- `src/tunacode/ui/context_panel.py:176` defines `is_widget_within_field(widget: DOMNode | None, root: DOMNode, *, field_id: str) -> bool`; `src/tunacode/ui/context_panel.py:179` probes `current` for `id`
+- `src/tunacode/ui/clipboard.py:18` defines `_callable_name(callback: Callable[..., object]) -> str`; `src/tunacode/ui/clipboard.py:19` probes `callback` for `__name__`
+- `src/tunacode/ui/command_registry.py:15` defines `CommandSpec`; `src/tunacode/ui/command_registry.py:49` defines `LazyCommandRegistry(Mapping[str, "Command"])`; `src/tunacode/ui/command_registry.py:56` defines `__getitem__(self, name: str) -> Command`; `src/tunacode/ui/command_registry.py:65` imports `tunacode.ui.commands.{spec.module_name}`; `src/tunacode/ui/command_registry.py:66` probes the imported module for `spec.class_name`
+- `src/tunacode/ui/renderers/errors.py:27` defines `EXCEPTION_CONTEXT_ATTRS`; `src/tunacode/ui/renderers/errors.py:38` defines `_extract_exception_context(exc: Exception) -> dict[str, str]`; `src/tunacode/ui/renderers/errors.py:42` probes `exc` for each attribute named in `EXCEPTION_CONTEXT_ATTRS`; `src/tunacode/ui/renderers/errors.py:77` defines `render_exception(exc: Exception) -> tuple[RenderableType, PanelMeta]`; `src/tunacode/ui/renderers/errors.py:81` probes `exc` for `suggested_fix`; `src/tunacode/ui/renderers/errors.py:82` probes `exc` for `recovery_commands`
+- `src/tunacode/ui/renderers/panels.py:85` defines `ToolDisplayData`; `src/tunacode/ui/renderers/panels.py:90` types `result: ToolResult | None`; `src/tunacode/ui/renderers/panels.py:371` defines `_extract_tool_result_text(result: ToolResult | None) -> str | None`; `src/tunacode/ui/renderers/panels.py:377` probes each item in `result.content` for `type`; `src/tunacode/ui/renderers/panels.py:379` probes each item for `text`
+- `src/tunacode/types/base.py:69` defines `ToolResult: TypeAlias = AgentToolResult`
+- `src/tunacode/types/canonical.py:51` defines `TextPart` with `content: str`; `src/tunacode/types/canonical.py:59` defines `ThoughtPart` with `content: str`; `src/tunacode/types/canonical.py:67` defines `SystemPromptPart` with `content: str`; `src/tunacode/types/canonical.py:85` defines `ToolResultTextPart` with `text: str | None`; `src/tunacode/types/canonical.py:94` defines `ToolResultImagePart` with `url: str | None`; `src/tunacode/types/canonical.py:125` defines `ToolReturnPart`; `src/tunacode/types/canonical.py:135` defines `RetryPromptPart` with `content: str`
+- `src/tunacode/ui/esc/types.py:17` defines `ShellRunnerProtocol`; `src/tunacode/ui/esc/handler.py:11` defines `handle_escape(..., shell_runner: ShellRunnerProtocol | None) -> None`
+
+## Baseline Inventory
+
+- `src/tunacode/core/compaction/controller.py:512` `getattr(message, COMPACTION_SUMMARY_KEY, None)`
+- `src/tunacode/core/logging/manager.py:86` `getattr(self._state_manager.session, "debug_mode", False)`
+- `src/tunacode/core/types/__init__.py:25` `getattr(importlib.import_module(module_name, __name__), name)`
+- `src/tunacode/ui/app.py:632` `getattr(self, "_shell_runner", None)`
+- `src/tunacode/ui/clipboard.py:19` `getattr(callback, "__name__", repr(callback))`
+- `src/tunacode/ui/command_registry.py:66` `getattr(module, spec.class_name)`
+- `src/tunacode/ui/context_panel.py:179` `getattr(current, "id", None)`
+- `src/tunacode/ui/renderers/__init__.py:30` `getattr(importlib.import_module(module_name, __name__), name)`
+- `src/tunacode/ui/renderers/errors.py:42` `getattr(exc, attr)`
+- `src/tunacode/ui/renderers/errors.py:81` `getattr(exc, "suggested_fix", None)`
+- `src/tunacode/ui/renderers/errors.py:82` `getattr(exc, "recovery_commands", None)`
+- `src/tunacode/ui/renderers/panels.py:377` `getattr(item, "type", None)`
+- `src/tunacode/ui/renderers/panels.py:379` `getattr(item, "text", None)`
+- `src/tunacode/ui/request_debug.py:397` `getattr(self._app.state_manager, "session", None)`
+- `src/tunacode/ui/request_debug.py:398` `getattr(session, "debug_mode", False)`
+- `src/tunacode/ui/request_debug.py:465` `getattr(self._app, "request_queue", None)`
+- `src/tunacode/ui/request_debug.py:469` `getattr(queue, "qsize", None)`
+- `src/tunacode/ui/request_debug.py:478` `getattr(queue, "items", None)`
+- `src/tunacode/ui/thinking_state.py:15` `getattr(app, "editor", None)`
+- `src/tunacode/ui/thinking_state.py:16` `getattr(editor, "value", "")`
+- `src/tunacode/ui/thinking_state.py:23` `getattr(app, "_last_editor_keypress_at", 0.0)`
+- `src/tunacode/ui/widgets/__init__.py:29` `getattr(importlib.import_module(module_name, __name__), name)`
+- `src/tunacode/ui/widgets/editor.py:83` `getattr(self, "app", None)`
+- `src/tunacode/ui/widgets/editor.py:86` `getattr(app, "_request_debug", None)`
+- `src/tunacode/ui/widgets/editor.py:90` `getattr(self, "has_paste_buffer", False)`
+- `src/tunacode/utils/messaging/token_counter.py:50` `getattr(part, "content", None)`
+
+## Patterns Found
+
+- Module export indirection through mapping tables and module `__getattr__`:
+  - `src/tunacode/core/types/__init__.py:8`
+  - `src/tunacode/core/types/__init__.py:21`
+  - `src/tunacode/ui/renderers/__init__.py:8`
+  - `src/tunacode/ui/renderers/__init__.py:26`
+  - `src/tunacode/ui/widgets/__init__.py:8`
+  - `src/tunacode/ui/widgets/__init__.py:25`
+
+- Runtime state probing against app/session/editor objects:
+  - `src/tunacode/core/logging/manager.py:86`
+  - `src/tunacode/ui/app.py:632`
+  - `src/tunacode/ui/request_debug.py:397`
+  - `src/tunacode/ui/request_debug.py:398`
+  - `src/tunacode/ui/request_debug.py:465`
+  - `src/tunacode/ui/request_debug.py:469`
+  - `src/tunacode/ui/request_debug.py:478`
+  - `src/tunacode/ui/thinking_state.py:15`
+  - `src/tunacode/ui/thinking_state.py:16`
+  - `src/tunacode/ui/thinking_state.py:23`
+  - `src/tunacode/ui/widgets/editor.py:83`
+  - `src/tunacode/ui/widgets/editor.py:86`
+  - `src/tunacode/ui/widgets/editor.py:90`
+  - `src/tunacode/ui/context_panel.py:179`
+
+- Exception metadata probing:
+  - `src/tunacode/ui/renderers/errors.py:27`
+  - `src/tunacode/ui/renderers/errors.py:42`
+  - `src/tunacode/ui/renderers/errors.py:81`
+  - `src/tunacode/ui/renderers/errors.py:82`
+
+- Message and tool payload probing:
+  - `src/tunacode/core/compaction/controller.py:512`
+  - `src/tunacode/utils/messaging/token_counter.py:50`
+  - `src/tunacode/ui/renderers/panels.py:377`
+  - `src/tunacode/ui/renderers/panels.py:379`
+
+- Callable and module/class-name probing:
+  - `src/tunacode/ui/clipboard.py:19`
+  - `src/tunacode/ui/command_registry.py:66`
+
+## Dependencies
+
+- `src/tunacode/core/compaction/controller.py:47` imports `StateManagerProtocol` from `tunacode.core.types`; `src/tunacode/core/types/__init__.py:12` maps `StateManagerProtocol` to `.state`; `src/tunacode/core/types/state.py:49` defines the protocol
+- `src/tunacode/core/logging/manager.py:13` imports `StateManagerProtocol` from `tunacode.core.types`; `src/tunacode/core/types/state.py:57` defines `session`; `src/tunacode/core/types/state.py:29` includes `debug_mode: bool`
+- `src/tunacode/ui/app.py:39` imports context-panel helpers from `tunacode.ui.context_panel`; `src/tunacode/ui/app.py:60` imports `RequestDebugTracer` and `SubmissionTrace` from `tunacode.ui.request_debug`; `src/tunacode/ui/app.py:68` imports widgets from `tunacode.ui.widgets`
+- `src/tunacode/ui/request_debug.py:12` opens the `TYPE_CHECKING` block and `src/tunacode/ui/request_debug.py:13` imports `TextualReplApp`; `src/tunacode/ui/app.py:156` constructs `RequestDebugTracer(self)`; `src/tunacode/ui/commands/debug.py:23` imports `build_request_debug_thresholds_message` from `tunacode.ui.request_debug`; `src/tunacode/ui/request_bridge.py:9` imports `BridgeDrainBatch` from `tunacode.ui.request_debug`
+- `src/tunacode/ui/thinking_state.py:11` imports `TextualReplApp` only under `TYPE_CHECKING`; `src/tunacode/ui/app.py:771`, `src/tunacode/ui/app.py:776`, `src/tunacode/ui/app.py:781`, and `src/tunacode/ui/app.py:786` lazily import thinking-state helpers
+- `src/tunacode/ui/widgets/editor.py:18` imports `EditorSubmitRequested` from `.messages`; `src/tunacode/ui/app.py:165` constructs `Editor()` and stores it on `self.editor`
+- `src/tunacode/ui/command_registry.py:65` imports per-command modules under `tunacode.ui.commands`; `src/tunacode/ui/commands/__init__.py:7` imports `COMMANDS`; `src/tunacode/ui/commands/__init__.py:28` indexes `COMMANDS[cmd_name]`; `src/tunacode/ui/commands/help.py:23` and `src/tunacode/ui/widgets/command_autocomplete.py:8` import `COMMAND_DESCRIPTIONS`
+- `src/tunacode/ui/renderers/errors.py:7` imports `ErrorDisplayData` and `RichPanelRenderer` from `tunacode.ui.renderers.panels`; `src/tunacode/ui/renderers/search.py:13` imports `RichPanelRenderer` and `SearchResultData` from the same module
+- `src/tunacode/ui/renderers/panels.py:20` imports `ToolResult` from `tunacode.types`; `src/tunacode/types/base.py:69` aliases `ToolResult` to `AgentToolResult`
+- `src/tunacode/core/compaction/summarizer.py:18` imports `estimate_message_tokens` from `tunacode.utils.messaging`; `src/tunacode/utils/messaging/__init__.py:15` re-exports `estimate_message_tokens`
+
+## Symbol Index
+
+- `src/tunacode/core/compaction/controller.py:91` `CompactionController`
+- `src/tunacode/core/compaction/controller.py:508` `_is_compaction_summary_message`
+- `src/tunacode/core/logging/manager.py:22` `LogManager`
+- `src/tunacode/core/types/__init__.py:21` `__getattr__`
+- `src/tunacode/core/types/state.py:24` `SessionStateProtocol`
+- `src/tunacode/core/types/state.py:49` `StateManagerProtocol`
+- `src/tunacode/utils/messaging/token_counter.py:35` `estimate_message_tokens`
+- `src/tunacode/ui/app.py:90` `TextualReplApp`
+- `src/tunacode/ui/clipboard.py:18` `_callable_name`
+- `src/tunacode/ui/command_registry.py:15` `CommandSpec`
+- `src/tunacode/ui/command_registry.py:49` `LazyCommandRegistry`
+- `src/tunacode/ui/context_panel.py:176` `is_widget_within_field`
+- `src/tunacode/ui/renderers/__init__.py:26` `__getattr__`
+- `src/tunacode/ui/renderers/errors.py:38` `_extract_exception_context`
+- `src/tunacode/ui/renderers/errors.py:77` `render_exception`
+- `src/tunacode/ui/renderers/panels.py:85` `ToolDisplayData`
+- `src/tunacode/ui/renderers/panels.py:96` `ErrorDisplayData`
+- `src/tunacode/ui/renderers/panels.py:106` `SearchResultData`
+- `src/tunacode/ui/renderers/panels.py:116` `RichPanelRenderer`
+- `src/tunacode/ui/renderers/panels.py:371` `_extract_tool_result_text`
+- `src/tunacode/ui/request_debug.py:28` `BridgeDrainBatch`
+- `src/tunacode/ui/request_debug.py:42` `SubmissionTrace`
+- `src/tunacode/ui/request_debug.py:113` `RequestDebugTracer`
+- `src/tunacode/ui/thinking_state.py:14` `_editor_has_draft`
+- `src/tunacode/ui/thinking_state.py:20` `_has_recent_editor_keypress`
+- `src/tunacode/ui/widgets/__init__.py:25` `__getattr__`
+- `src/tunacode/ui/widgets/editor.py:39` `Editor`
+
+## Script Output Notes
+
+- `research-phase/scripts/structure-map.sh src/tunacode --with-stats` returned the package tree and reported `173` Python files and `173` total code files
+- `research-phase/scripts/ast-scan.sh all src/tunacode` returned the function, class, export, import, type, and API-route section headers with no matches listed under them
+- `research-phase/scripts/symbol-index.sh src/tunacode` returned the exported-function, exported-class, exported-type/interface, exported-constant, and Python-public-symbol section headers with no matches listed under them
+- `research-phase/scripts/dependency-graph.sh ./ --file src/tunacode/ui/request_debug.py` reported `src/tunacode/ui/commands/debug.py` under "Files that import src/tunacode/ui/request_debug.py"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-04-12
+Last Updated: 2026-04-13
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.
@@ -115,6 +115,7 @@ Last Updated: 2026-04-12
 ## Quality Constraints (Do not break)
 - `README.md` and docs should stay consistent with implementation.
 - Keep `AGENTS.md` updated with `Last Updated: YYYY-MM-DD` whenever `src/` or `docs/` changes.
+- The 2026-04-13 getattr baseline follow-up reduced the scoped UI/runtime and owned-exception `getattr(...)` usage; the committed ast-grep baseline should stay aligned with those removals.
 - Do not add TunaCode-owned message-contract wrappers around tinyagent message types; use tinyagent models directly in memory and keep dict payloads at real boundaries.
 - Preserve existing architecture order rules; do not add new imports across forbidden layers.
 - Treat current file-length allowlist entries as temporary debt only. Do not add any new file-specific exemptions to the `>600` line rule; fix the enforcement path or split the code instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-04-13
+Last Updated: 2026-04-14
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.

--- a/rules/ast-grep/baseline/no-getattr-in-src.json
+++ b/rules/ast-grep/baseline/no-getattr-in-src.json
@@ -6,18 +6,8 @@
   },
   {
     "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/core/logging/manager.py",
-    "text": "getattr(self._state_manager.session, \"debug_mode\", False)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
     "file": "src/tunacode/core/types/__init__.py",
     "text": "getattr(importlib.import_module(module_name, __name__), name)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/app.py",
-    "text": "getattr(self, \"_shell_runner\", None)"
   },
   {
     "rule_id": "no-getattr-in-src",
@@ -31,28 +21,8 @@
   },
   {
     "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/context_panel.py",
-    "text": "getattr(current, \"id\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
     "file": "src/tunacode/ui/renderers/__init__.py",
     "text": "getattr(importlib.import_module(module_name, __name__), name)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/renderers/errors.py",
-    "text": "getattr(exc, \"recovery_commands\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/renderers/errors.py",
-    "text": "getattr(exc, \"suggested_fix\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/renderers/errors.py",
-    "text": "getattr(exc, attr)"
   },
   {
     "rule_id": "no-getattr-in-src",
@@ -66,63 +36,8 @@
   },
   {
     "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/request_debug.py",
-    "text": "getattr(queue, \"items\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/request_debug.py",
-    "text": "getattr(queue, \"qsize\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/request_debug.py",
-    "text": "getattr(self._app, \"request_queue\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/request_debug.py",
-    "text": "getattr(self._app.state_manager, \"session\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/request_debug.py",
-    "text": "getattr(session, \"debug_mode\", False)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/thinking_state.py",
-    "text": "getattr(app, \"_last_editor_keypress_at\", 0.0)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/thinking_state.py",
-    "text": "getattr(app, \"editor\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/thinking_state.py",
-    "text": "getattr(editor, \"value\", \"\")"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
     "file": "src/tunacode/ui/widgets/__init__.py",
     "text": "getattr(importlib.import_module(module_name, __name__), name)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/widgets/editor.py",
-    "text": "getattr(app, \"_request_debug\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/widgets/editor.py",
-    "text": "getattr(self, \"app\", None)"
-  },
-  {
-    "rule_id": "no-getattr-in-src",
-    "file": "src/tunacode/ui/widgets/editor.py",
-    "text": "getattr(self, \"has_paste_buffer\", False)"
   },
   {
     "rule_id": "no-getattr-in-src",

--- a/src/tunacode/core/logging/manager.py
+++ b/src/tunacode/core/logging/manager.py
@@ -83,7 +83,7 @@ class LogManager:
         """Check current debug mode state."""
         if self._state_manager is None:
             return False
-        return getattr(self._state_manager.session, "debug_mode", False)
+        return self._state_manager.session.debug_mode
 
     def log(self, record: LogRecord) -> None:
         """Route a log record to all handlers."""

--- a/src/tunacode/ui/app.py
+++ b/src/tunacode/ui/app.py
@@ -629,7 +629,7 @@ class TextualReplApp(App[None]):
         current_request_task = self._current_request_task
         esc_handler.handle_escape(
             current_request_task=current_request_task,
-            shell_runner=getattr(self, "_shell_runner", None),
+            shell_runner=self._shell_runner,
         )
 
     def start_shell_command(self, raw_cmd: str) -> None:

--- a/src/tunacode/ui/context_panel.py
+++ b/src/tunacode/ui/context_panel.py
@@ -176,7 +176,7 @@ def build_skills_field(skill_entries: list[tuple[str, str]]) -> tuple[str, Text]
 def is_widget_within_field(widget: DOMNode | None, root: DOMNode, *, field_id: str) -> bool:
     current = widget
     while current is not None and current is not root:
-        if getattr(current, "id", None) == field_id:
+        if current.id == field_id:
             return True
         current = current.parent
 

--- a/src/tunacode/ui/renderers/errors.py
+++ b/src/tunacode/ui/renderers/errors.py
@@ -4,6 +4,18 @@ from __future__ import annotations
 
 from rich.console import RenderableType
 
+from tunacode.exceptions import (
+    AgentError,
+    ConfigurationError,
+    ContextOverflowError,
+    FileOperationError,
+    GitOperationError,
+    ModelConfigurationError,
+    SetupValidationError,
+    ToolExecutionError,
+    TunaCodeError,
+    ValidationError,
+)
 from tunacode.ui.renderers.panels import ErrorDisplayData, RichPanelRenderer
 from tunacode.ui.widgets.chat import PanelMeta
 
@@ -24,25 +36,35 @@ ERROR_SEVERITY_MAP: dict[str, str] = {
     "StateError": "info",
 }
 
-EXCEPTION_CONTEXT_ATTRS: dict[str, str] = {
-    "tool_name": "Tool",
-    "path": "Path",
-    "operation": "Operation",
-    "server_name": "Server",
-    "model": "Model",
-    "step": "Step",
-    "validation_type": "Validation",
-}
-
-
-def _extract_exception_context(exc: Exception) -> dict[str, str]:
+def _extract_tunacode_exception_context(exc: TunaCodeError) -> dict[str, str]:
     context: dict[str, str] = {}
-    for attr, label in EXCEPTION_CONTEXT_ATTRS.items():
-        if hasattr(exc, attr):
-            value = getattr(exc, attr)
-            if value is not None:
-                context[label] = str(value)
+    if isinstance(exc, ToolExecutionError):
+        context["Tool"] = str(exc.tool_name)
+    if isinstance(exc, FileOperationError):
+        context["Path"] = str(exc.path)
+        context["Operation"] = str(exc.operation)
+    elif isinstance(exc, GitOperationError):
+        context["Operation"] = str(exc.operation)
+    if isinstance(exc, ModelConfigurationError | ContextOverflowError):
+        context["Model"] = str(exc.model)
+    if isinstance(exc, SetupValidationError):
+        context["Validation"] = str(exc.validation_type)
     return context
+
+
+def _extract_tunacode_exception_metadata(
+    exc: TunaCodeError,
+) -> tuple[str | None, list[str] | None]:
+    suggested_fix = None
+    recovery_commands = None
+
+    if isinstance(exc, ConfigurationError | ValidationError | ToolExecutionError | AgentError):
+        suggested_fix = exc.suggested_fix
+
+    if isinstance(exc, ToolExecutionError):
+        recovery_commands = exc.recovery_commands
+
+    return suggested_fix, recovery_commands
 
 
 DEFAULT_RECOVERY_COMMANDS: dict[str, list[str]] = {
@@ -78,10 +100,12 @@ def render_exception(exc: Exception) -> tuple[RenderableType, PanelMeta]:
     error_type = type(exc).__name__
     severity = ERROR_SEVERITY_MAP.get(error_type, "error")
 
-    suggested_fix = getattr(exc, "suggested_fix", None)
-    recovery_commands = getattr(exc, "recovery_commands", None)
-
-    context = _extract_exception_context(exc)
+    suggested_fix = None
+    recovery_commands = None
+    context: dict[str, str] = {}
+    if isinstance(exc, TunaCodeError):
+        suggested_fix, recovery_commands = _extract_tunacode_exception_metadata(exc)
+        context = _extract_tunacode_exception_context(exc)
 
     if not recovery_commands:
         recovery_commands = DEFAULT_RECOVERY_COMMANDS.get(error_type)

--- a/src/tunacode/ui/renderers/errors.py
+++ b/src/tunacode/ui/renderers/errors.py
@@ -16,6 +16,7 @@ from tunacode.exceptions import (
     TunaCodeError,
     ValidationError,
 )
+
 from tunacode.ui.renderers.panels import ErrorDisplayData, RichPanelRenderer
 from tunacode.ui.widgets.chat import PanelMeta
 
@@ -35,6 +36,7 @@ ERROR_SEVERITY_MAP: dict[str, str] = {
     "UserAbortError": "info",
     "StateError": "info",
 }
+
 
 def _extract_tunacode_exception_context(exc: TunaCodeError) -> dict[str, str]:
     match exc:

--- a/src/tunacode/ui/renderers/errors.py
+++ b/src/tunacode/ui/renderers/errors.py
@@ -37,34 +37,35 @@ ERROR_SEVERITY_MAP: dict[str, str] = {
 }
 
 def _extract_tunacode_exception_context(exc: TunaCodeError) -> dict[str, str]:
-    context: dict[str, str] = {}
-    if isinstance(exc, ToolExecutionError):
-        context["Tool"] = str(exc.tool_name)
-    if isinstance(exc, FileOperationError):
-        context["Path"] = str(exc.path)
-        context["Operation"] = str(exc.operation)
-    elif isinstance(exc, GitOperationError):
-        context["Operation"] = str(exc.operation)
-    if isinstance(exc, ModelConfigurationError | ContextOverflowError):
-        context["Model"] = str(exc.model)
-    if isinstance(exc, SetupValidationError):
-        context["Validation"] = str(exc.validation_type)
-    return context
+    match exc:
+        case ToolExecutionError(tool_name=tool_name):
+            return {"Tool": str(tool_name)}
+        case FileOperationError(path=path, operation=operation):
+            return {"Path": str(path), "Operation": str(operation)}
+        case GitOperationError(operation=operation):
+            return {"Operation": str(operation)}
+        case ModelConfigurationError(model=model) | ContextOverflowError(model=model):
+            return {"Model": str(model)}
+        case SetupValidationError(validation_type=validation_type):
+            return {"Validation": str(validation_type)}
+        case _:
+            return {}
 
 
 def _extract_tunacode_exception_metadata(
     exc: TunaCodeError,
 ) -> tuple[str | None, list[str] | None]:
-    suggested_fix = None
-    recovery_commands = None
-
-    if isinstance(exc, ConfigurationError | ValidationError | ToolExecutionError | AgentError):
-        suggested_fix = exc.suggested_fix
-
-    if isinstance(exc, ToolExecutionError):
-        recovery_commands = exc.recovery_commands
-
-    return suggested_fix, recovery_commands
+    match exc:
+        case ToolExecutionError(suggested_fix=suggested_fix, recovery_commands=recovery_commands):
+            return suggested_fix, recovery_commands
+        case (
+            ConfigurationError(suggested_fix=suggested_fix)
+            | ValidationError(suggested_fix=suggested_fix)
+            | AgentError(suggested_fix=suggested_fix)
+        ):
+            return suggested_fix, None
+        case _:
+            return None, None
 
 
 DEFAULT_RECOVERY_COMMANDS: dict[str, list[str]] = {

--- a/src/tunacode/ui/request_debug.py
+++ b/src/tunacode/ui/request_debug.py
@@ -394,8 +394,7 @@ class RequestDebugTracer:
 
     @property
     def _enabled(self) -> bool:
-        session = getattr(self._app.state_manager, "session", None)
-        return bool(getattr(session, "debug_mode", False))
+        return self._app.state_manager.session.debug_mode
 
     def _complete_input_probe(self, probe: _PendingInputProbe) -> None:
         if self._pending_input_probe is not probe:
@@ -462,24 +461,8 @@ class RequestDebugTracer:
         )
 
     def _queue_size(self) -> int:
-        queue = getattr(self._app, "request_queue", None)
-        if queue is None:
-            return 0
-
-        qsize = getattr(queue, "qsize", None)
-        if callable(qsize):
-            try:
-                size = qsize()
-            except TypeError:
-                size = 0
-            if isinstance(size, int):
-                return max(0, size)
-
-        items = getattr(queue, "items", None)
-        if isinstance(items, list):
-            return len(items)
-
-        return 0
+        size = self._app.request_queue.qsize()
+        return max(0, size) if isinstance(size, int) else 0
 
     def _emit(self, message: str) -> None:
         get_logger().lifecycle(message)

--- a/src/tunacode/ui/thinking_state.py
+++ b/src/tunacode/ui/thinking_state.py
@@ -12,15 +12,13 @@ if TYPE_CHECKING:
 
 
 def _editor_has_draft(app: TextualReplApp) -> bool:
-    editor = getattr(app, "editor", None)
-    editor_value = getattr(editor, "value", "")
-    return bool(editor_value.strip())
+    return bool(app.editor.value.strip())
 
 
 def _has_recent_editor_keypress(app: TextualReplApp) -> bool:
     if not _editor_has_draft(app):
         return False
-    last_keypress_at = getattr(app, "_last_editor_keypress_at", 0.0)
+    last_keypress_at = app._last_editor_keypress_at
     if last_keypress_at <= 0.0:
         return False
     elapsed_ms = (time.monotonic() - last_keypress_at) * app.MILLISECONDS_PER_SECOND

--- a/src/tunacode/ui/widgets/editor.py
+++ b/src/tunacode/ui/widgets/editor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
 
 from rich.cells import cell_len
 from rich.style import Style, StyleType
@@ -17,6 +18,9 @@ from textual.strip import Strip
 from textual.widgets import Input
 
 from .messages import EditorSubmitRequested
+
+if TYPE_CHECKING:
+    from tunacode.ui.app import TextualReplApp
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,7 +86,7 @@ class Editor(Input):
         """Handle key events for bash-mode auto-spacing."""
         if event.character or event.key in {"backspace", "delete"}:
             try:
-                app = self.app
+                app = cast("TextualReplApp", self.app)
             except NoActiveAppError:
                 app = None
 

--- a/src/tunacode/ui/widgets/editor.py
+++ b/src/tunacode/ui/widgets/editor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from rich.cells import cell_len
 from rich.style import Style, StyleType
@@ -21,6 +21,8 @@ from .messages import EditorSubmitRequested
 
 if TYPE_CHECKING:
     from tunacode.ui.app import TextualReplApp
+else:
+    TextualReplApp = Any
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,7 +88,7 @@ class Editor(Input):
         """Handle key events for bash-mode auto-spacing."""
         if event.character or event.key in {"backspace", "delete"}:
             try:
-                app = cast("TextualReplApp", self.app)
+                app = cast(TextualReplApp, self.app)
             except NoActiveAppError:
                 app = None
 

--- a/src/tunacode/ui/widgets/editor.py
+++ b/src/tunacode/ui/widgets/editor.py
@@ -10,7 +10,6 @@ from rich.cells import cell_len
 from rich.style import Style, StyleType
 from rich.text import Text
 from textual import events
-from textual._context import NoActiveAppError
 from textual.binding import Binding
 from textual.expand_tabs import expand_tabs_inline
 from textual.geometry import Offset, Region, Size
@@ -86,15 +85,10 @@ class Editor(Input):
 
     def on_key(self, event: events.Key) -> None:
         """Handle key events for bash-mode auto-spacing."""
-        if event.character or event.key in {"backspace", "delete"}:
-            try:
-                app = cast(TextualReplApp, self.app)
-            except NoActiveAppError:
-                app = None
-
-            if app is not None:
-                app._last_editor_keypress_at = time.monotonic()
-                app._request_debug.note_editor_keypress(key_label=event.character or event.key)
+        if (event.character or event.key in {"backspace", "delete"}) and self.is_mounted:
+            app = cast(TextualReplApp, self.app)
+            app._last_editor_keypress_at = time.monotonic()
+            app._request_debug.note_editor_keypress(key_label=event.character or event.key)
 
         if self.has_paste_buffer and not self.value and event.key == "backspace":
             event.prevent_default()

--- a/src/tunacode/ui/widgets/editor.py
+++ b/src/tunacode/ui/widgets/editor.py
@@ -9,6 +9,7 @@ from rich.cells import cell_len
 from rich.style import Style, StyleType
 from rich.text import Text
 from textual import events
+from textual._context import NoActiveAppError
 from textual.binding import Binding
 from textual.expand_tabs import expand_tabs_inline
 from textual.geometry import Offset, Region, Size
@@ -80,15 +81,16 @@ class Editor(Input):
     def on_key(self, event: events.Key) -> None:
         """Handle key events for bash-mode auto-spacing."""
         if event.character or event.key in {"backspace", "delete"}:
-            app = getattr(self, "app", None)
+            try:
+                app = self.app
+            except NoActiveAppError:
+                app = None
+
             if app is not None:
                 app._last_editor_keypress_at = time.monotonic()
-                tracer = getattr(app, "_request_debug", None)
-                if tracer is not None:
-                    tracer.note_editor_keypress(key_label=event.character or event.key)
+                app._request_debug.note_editor_keypress(key_label=event.character or event.key)
 
-        has_paste_buffer = bool(getattr(self, "has_paste_buffer", False))
-        if has_paste_buffer and not self.value and event.key == "backspace":
+        if self.has_paste_buffer and not self.value and event.key == "backspace":
             event.prevent_default()
             self._clear_paste_buffer()
             return

--- a/tests/unit/core/test_logging.py
+++ b/tests/unit/core/test_logging.py
@@ -95,6 +95,18 @@ class TestLogManagerProperties:
         file_handlers = [h for h in logger._handlers if isinstance(h, FileHandler)]
         assert logger.log_path == file_handlers[0].log_path
 
+    def test_debug_mode_reads_attached_session_flag(self):
+        """debug_mode reflects the attached session state."""
+        logger = get_logger()
+        state_manager = StateManager()
+        logger.set_state_manager(state_manager)
+
+        assert logger.debug_mode is False
+
+        state_manager.session.debug_mode = True
+
+        assert logger.debug_mode is True
+
 
 class TestLogRecord:
     """Tests for LogRecord dataclass."""

--- a/tests/unit/core/test_provider_error_surfacing.py
+++ b/tests/unit/core/test_provider_error_surfacing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from tunacode.exceptions import AgentError
+from tunacode.exceptions import AgentError, ContextOverflowError, ToolExecutionError
 
 from tunacode.core.agents.helpers import coerce_error_text, is_context_overflow_error
 
@@ -48,3 +48,45 @@ def test_agent_error_renders_via_render_exception() -> None:
     console.print(content)
     rendered = console.export_text()
     assert "unauthorized" in rendered
+
+
+def test_render_exception_surfaces_tool_execution_metadata() -> None:
+    from rich.console import Console
+
+    from tunacode.ui.renderers.errors import render_exception
+
+    exc = ToolExecutionError(
+        tool_name="formatter",
+        message="tool failed",
+        suggested_fix="Use valid arguments",
+        recovery_commands=["tunacode --retry"],
+    )
+
+    content, _meta = render_exception(exc)
+
+    console = Console(record=True, width=120)
+    console.print(content)
+    rendered = console.export_text()
+    assert "formatter" in rendered
+    assert "Use valid arguments" in rendered
+    assert "tunacode --retry" in rendered
+
+
+def test_render_exception_context_overflow_includes_model_context() -> None:
+    from rich.console import Console
+
+    from tunacode.ui.renderers.errors import render_exception
+
+    exc = ContextOverflowError(
+        estimated_tokens=250_000,
+        max_tokens=200_000,
+        model="openrouter:openai/gpt-4.1",
+    )
+
+    content, _meta = render_exception(exc)
+
+    console = Console(record=True, width=120)
+    console.print(content)
+    rendered = console.export_text()
+    assert "openrouter:openai/gpt-4.1" in rendered
+    assert "Compact the session or reduce context size before retrying." in rendered

--- a/tests/unit/ui/test_context_panel.py
+++ b/tests/unit/ui/test_context_panel.py
@@ -11,7 +11,7 @@ from tunacode.ui.context_panel import is_widget_within_field
 @dataclass
 class _NodeStub:
     id: str | None
-    parent: "_NodeStub | None" = None
+    parent: _NodeStub | None = None
 
 
 def test_is_widget_within_field_matches_ancestor_id() -> None:

--- a/tests/unit/ui/test_context_panel.py
+++ b/tests/unit/ui/test_context_panel.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from textual.dom import DOMNode
+
+from tunacode.ui.context_panel import is_widget_within_field
+
+
+@dataclass
+class _NodeStub:
+    id: str | None
+    parent: "_NodeStub | None" = None
+
+
+def test_is_widget_within_field_matches_ancestor_id() -> None:
+    root = _NodeStub(id="root")
+    field = _NodeStub(id="field-model", parent=root)
+    child = _NodeStub(id="child", parent=field)
+
+    assert is_widget_within_field(
+        cast(DOMNode, child),
+        cast(DOMNode, root),
+        field_id="field-model",
+    )
+
+
+def test_is_widget_within_field_stops_at_root_boundary() -> None:
+    root = _NodeStub(id="root")
+    sibling = _NodeStub(id="field-skills", parent=root)
+    child = _NodeStub(id="child", parent=sibling)
+
+    assert not is_widget_within_field(
+        cast(DOMNode, child),
+        cast(DOMNode, sibling),
+        field_id="root",
+    )

--- a/tests/unit/utils/test_shell_command_escape.py
+++ b/tests/unit/utils/test_shell_command_escape.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import cast
+from unittest.mock import MagicMock
 
 import pytest
 from textual._context import NoActiveAppError
@@ -113,11 +114,32 @@ def test_escape_does_not_clear_editor_when_no_request_or_shell_running() -> None
         {
             "_current_request_task": None,
             "_esc_handler": EscHandler(),
-            "_shell_command_task": None,
+            "_shell_runner": None,
         },
     )()
     TextualReplApp.action_cancel_request(fake_app)
     assert fake_app._current_request_task is None
+
+
+def test_escape_passes_shell_runner_to_handler() -> None:
+    shell_runner = object()
+    esc_handler = MagicMock()
+    fake_app = type(
+        "FakeApp",
+        (),
+        {
+            "_current_request_task": "worker",
+            "_esc_handler": esc_handler,
+            "_shell_runner": shell_runner,
+        },
+    )()
+
+    TextualReplApp.action_cancel_request(fake_app)
+
+    esc_handler.handle_escape.assert_called_once_with(
+        current_request_task="worker",
+        shell_runner=shell_runner,
+    )
 
 
 def test_bang_toggles_on_when_empty() -> None:

--- a/tests/unit/utils/test_shell_command_escape.py
+++ b/tests/unit/utils/test_shell_command_escape.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import cast
 
 import pytest
+from textual._context import NoActiveAppError
 
 from tunacode.ui.app import TextualReplApp
 from tunacode.ui.commands import handle_command
@@ -27,9 +28,21 @@ class _FakeKeyEvent:
 class _EditorKeyHandlingStub:
     value: str
     cursor_position: int = 0
+    _app: object | None = None
+    _has_paste_buffer: bool = False
 
     BASH_MODE_PREFIX = Editor.BASH_MODE_PREFIX
     BASH_MODE_PREFIX_WITH_SPACE = Editor.BASH_MODE_PREFIX_WITH_SPACE
+
+    @property
+    def app(self) -> object:
+        if self._app is None:
+            raise NoActiveAppError()
+        return self._app
+
+    @property
+    def has_paste_buffer(self) -> bool:
+        return self._has_paste_buffer
 
 
 @pytest.mark.asyncio

--- a/tests/unit/utils/test_shell_command_escape.py
+++ b/tests/unit/utils/test_shell_command_escape.py
@@ -7,7 +7,6 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-from textual._context import NoActiveAppError
 
 from tunacode.ui.app import TextualReplApp
 from tunacode.ui.commands import handle_command
@@ -29,17 +28,11 @@ class _FakeKeyEvent:
 class _EditorKeyHandlingStub:
     value: str
     cursor_position: int = 0
-    _app: object | None = None
+    is_mounted: bool = False
     _has_paste_buffer: bool = False
 
     BASH_MODE_PREFIX = Editor.BASH_MODE_PREFIX
     BASH_MODE_PREFIX_WITH_SPACE = Editor.BASH_MODE_PREFIX_WITH_SPACE
-
-    @property
-    def app(self) -> object:
-        if self._app is None:
-            raise NoActiveAppError()
-        return self._app
 
     @property
     def has_paste_buffer(self) -> bool:


### PR DESCRIPTION
## Description

Retire the remaining TunaCode-owned `getattr(...)` stragglers in `src/` as part of issue #466.

- remove the remaining fallback attribute probing in the touched UI/runtime paths
- refactor exception context extraction helpers to use structural pattern matching
- refresh the `ast-grep` baseline and add focused regression coverage for the affected behavior
- fix the post-open `make check` blockers surfaced by hook formatting, runtime typing, and a stale cache-only directory

Closes #466

## Pre-PR Checklist
- [ ] **Rebased onto master** (`git fetch origin && git rebase origin/master`)
- [x] **All pre-commit hooks pass** (`uv run pre-commit run --all-files`)
- [ ] Tech debt baseline updated (if adding TODO/FIXME markers: `uv run python scripts/todo_scanner.py --output scripts/todo_baseline.json`)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement
- [x] Refactoring (code improvement without changing functionality)
- [ ] Tool/Agent enhancement (improvements to LLM tools or agents)

## Testing
- [x] All existing tests pass (`uv run pytest`)
- [x] New tests have been added to cover the changes
- [x] Tests have been run locally
- [ ] Golden/character tests established for new features

### Test Coverage
- Current coverage: ___%
- Coverage after changes: ___%

Local gate run:
- `make check`

Focused local tests run:
- `uv run pytest tests/unit/core/test_logging.py tests/unit/core/test_provider_error_surfacing.py tests/unit/ui/test_context_panel.py tests/unit/utils/test_shell_command_escape.py`

## Pre-commit Checks
- [x] All pre-commit hooks pass
- [x] Code formatted with `ruff format`
- [x] Code passes `ruff check` without warnings
- [x] No non-test Python file exceeds **600 lines**

## Checklist
- [x] My code follows the Python coding standards (type hints, f-strings, pathlib, etc.)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated documentation in `@documentation/` and `.claude/` directories
- [x] My changes generate no new warnings
- [ ] Dependencies are properly managed in `pyproject.toml`
- [ ] Any dependent changes have been merged and published
- [x] Created rollback point with clear commit message before changes

## Documentation Updates
- [ ] Updated relevant files in `@documentation/`
- [ ] Updated developer notes in `.claude/`
- [ ] README.md updated (if needed)

## Additional Notes
- This branch is 10 commits ahead of `origin/master`; the PR reflects the full issue-466 stack on this branch.
- Focused exception/rendering-related review reported no actionable regressions in the changed code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## State Management Changes

- Replaced defensive getattr probing with direct attribute access across UI and core state usages, making session and app fields explicit:
  - LogManager.debug_mode now returns self._state_manager.session.debug_mode (returns False earlier only when no state_manager is attached).
  - RequestDebugTracer._enabled reads self._app.state_manager.session.debug_mode directly; _queue_size assumes self._app.request_queue.qsize() exists.
  - thinking_state helpers and Editor key-handling now assume app.editor, app._last_editor_keypress_at, app._request_debug, and related attributes are present and initialized.
  - TextualReplApp.action_cancel_request now passes self._shell_runner directly to the escape handler (tests updated to use _shell_runner).

These changes shift responsibility to ensure the listed attributes are initialized at construction/attachment (tests added to validate the common paths).

## Exception Handling Refactor

- Replaced a generic attribute-scraping approach with typed structural pattern matching for TunaCodeError subclasses:
  - Removed the generic EXCEPTION_CONTEXT_ATTRS/loop-based extractor and introduced _extract_tunacode_exception_context(exc: TunaCodeError) using match/case to return focused context (Tool, Path+Operation, Model, Validation).
  - Added _extract_tunacode_exception_metadata(exc: TunaCodeError) to extract suggested_fix and recovery_commands (recovery_commands only for ToolExecutionError).
  - render_exception now initializes suggested_fix, recovery_commands, and context to defaults and only populates them when exc is a TunaCodeError; DEFAULT_RECOVERY_COMMANDS remains a fallback when recovery_commands is absent.
- This narrows extracted metadata to typed exceptions, reduces accidental exposure of arbitrary exception attributes, and removes the older generic scraping dead-path.

## Type Safety Improvements (and regressions)

- Added TYPE_CHECKING scaffolding and cast usage in Editor to narrow self.app to TextualReplApp for static type checkers.
- UI code now prefers typed direct access over dynamic getattr fallbacks, improving static analyzability and reducing silent fallbacks.
- Potential regressions: several call sites now will raise AttributeError if expected attributes are missing at runtime (e.g., session.debug_mode, request_queue.qsize(), editor attributes). The PR's tests and initialization code cover common cases, but callers must ensure proper initialization to avoid runtime errors.

## Dead Code Added or Removed

- Removed the legacy generic exception-attribute map and its extractor (dead/useless fallback logic).
- No new significant dead code introduced; overall changes reduced defensive scaffolding in favor of explicit fields.

## Remaining dynamic getattr usages under src/ (need review / intentional dynamic cases)
rg found these remaining occurrences that appear to be intentionally dynamic or in import/compaction plumbing:
- src/tunacode/utils/messaging/token_counter.py: getattr(part, "content", None)
- src/tunacode/ui/renderers/panels.py: getattr(item, "type", None) / getattr(item, "text", None)
- src/tunacode/ui/renderers/__init__.py: dynamic import getattr(importlib.import_module(...), name)
- src/tunacode/ui/command_registry.py: getattr(module, spec.class_name)
- src/tunacode/ui/clipboard.py: getattr(callback, "__name__", repr(callback))
- src/tunacode/core/types/__init__.py: dynamic import getattr(importlib.import_module(...), name)
- src/tunacode/core/compaction/controller.py: getattr(message, COMPACTION_SUMMARY_KEY, None)
- src/tunacode/ui/widgets/__init__.py: dynamic import getattr(importlib.import_module(...), name)

These align with the stated objective to retain truly dynamic getattr uses (imports, registry, message keys, optional content fields). They represent the remaining ast-grep baseline items that require intentional dynamic access.

## Tests & Baseline

- Added focused unit tests covering:
  - LogManager debug_mode reflecting attached StateManager.session flag.
  - is_widget_within_field traversal behavior.
  - render_exception preserving ToolExecutionError metadata (tool_name, suggested_fix, recovery_commands) and ContextOverflowError model context.
  - Adjusted existing test stubs to account for _shell_runner usage and Editor mounting/paste behavior.
- Ast-grep violations were reduced by addressing static cases; the remaining getattr occurrences above are intentional dynamic cases to be whitelisted/handled separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->