### PR TITLE
test: add flaky test detection with pytest-rerunfailures and historical report analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,6 +149,14 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      # Detect flaky tests from historical JSON reports
+      - id: flaky-tests
+        name: Check for flaky tests
+        entry: uv run python scripts/check-flaky-tests.py
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
       - id: ast-grep-getattr-ratchet
         name: Run ast-grep getattr ratchet
         entry: scripts/run_ast_grep_checks.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-04-27
+Last Updated: 2026-05-01
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-randomly>=3.15.0",  # Test isolation - randomize test order
     "pytest-timeout>=2.3.1",    # Test isolation - prevent hanging tests
     "pytest-json-report>=1.5.0",  # JSON test reports for historical tracking
+    "pytest-rerunfailures>=14",  # Flaky test detection - retry failed tests
     "hypothesis>=6.150.0",
 
     # Code quality and linting
@@ -347,6 +348,7 @@ dev = [
     "pytest-randomly>=3.15.0", # Test isolation - randomize test order
     "pytest-timeout>=2.3.1", # Test isolation - prevent hanging tests
     "pytest-json-report>=1.5.0", # JSON test reports for historical tracking
+    "pytest-rerunfailures>=14", # Flaky test detection - retry failed tests
     "hypothesis>=6.150.0",
 
     # Code quality and linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,6 +268,7 @@ DEP002 = [
     "pytest-randomly",
     "pytest-timeout",
     "pytest-json-report",
+    "pytest-rerunfailures",
     "hypothesis",
     "mypy",
     "bandit",

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,6 +25,8 @@ addopts =
     --json-report
     --json-report-file=.test_reports/latest.json
     --json-report-indent=2
+    --reruns 2
+    --reruns-delay 1
 
 # Coverage configuration (use with: pytest --cov)
 # Threshold enforced in CI via: pytest --cov --cov-fail-under=40
@@ -44,3 +46,4 @@ markers =
     hypothesis: property-based tests using hypothesis (may be slow),
     integration: tests requiring real API access (skipped by default),
     tmux: end-to-end tests that drive tunacode in a real tmux session (require tmux + API key)
+    flaky: tests that are known to be unreliable and may fail intermittently

--- a/scripts/check-flaky-tests.py
+++ b/scripts/check-flaky-tests.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Detect flaky tests by analyzing historical JSON test reports.
+
+A test is considered flaky if it has both passed and failed outcomes across
+different test runs. The script also flags tests with high duration variance
+as potentially unstable (e.g., due to external dependency timing).
+
+Usage:
+    uv run python scripts/check-flaky-tests.py [--min-runs N]
+"""
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, stdev
+
+REPORTS_DIR = Path(".test_reports")
+MIN_RUNS = 3  # require at least this many runs to detect flakiness
+
+
+def load_reports() -> list[dict]:
+    """Load all archived JSON test reports sorted by timestamp."""
+    reports = []
+    for path in sorted(REPORTS_DIR.glob("report_*.json")):
+        try:
+            with open(path) as f:
+                reports.append(json.load(f))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return reports
+
+
+def detect_outcome_flaky(reports: list[dict]) -> list[str]:
+    """Find tests that flip between passed and failed across runs."""
+    test_outcomes: dict[str, set[str]] = defaultdict(set)
+    for report in reports:
+        for test in report.get("tests", []):
+            outcome = test.get("outcome", "unknown")
+            test_outcomes[test["nodeid"]].add(outcome)
+
+    flaky_tests = []
+    for nodeid, outcomes in sorted(test_outcomes.items()):
+        passed = "passed" in outcomes
+        failed = "failed" in outcomes or "error" in outcomes
+        if passed and failed:
+            flaky_tests.append(nodeid)
+    return flaky_tests
+
+
+def detect_duration_flaky(reports: list[dict], coefficient_threshold: float = 0.5) -> list[str]:
+    """Find tests with high duration variance across runs (CV > threshold)."""
+    test_durations: dict[str, list[float]] = defaultdict(list)
+    for report in reports:
+        for test in report.get("tests", []):
+            duration = test.get("call", {}).get("duration", 0)
+            if duration > 0:
+                test_durations[test["nodeid"]].append(duration)
+
+    flaky_duration = []
+    for nodeid, durations in sorted(test_durations.items()):
+        if len(durations) < MIN_RUNS:
+            continue
+        avg = mean(durations)
+        if avg < 0.1:  # skip very fast tests - variance at low durations is noise
+            continue
+        sd = stdev(durations)
+        cv = sd / avg if avg > 0 else 0
+        if cv > coefficient_threshold:
+            flaky_duration.append((nodeid, cv, avg, sd))
+
+    flaky_duration.sort(key=lambda x: -x[1])
+    return [item[0] for item in flaky_duration]
+
+
+def find_flaky_tests(reports: list[dict]) -> tuple[list[str], list[str]]:
+    """Analyze reports and return outcome-flaky and duration-flaky tests."""
+    outcome_flaky = detect_outcome_flaky(reports)
+    duration_flaky = detect_duration_flaky(reports)
+    return outcome_flaky, duration_flaky
+
+
+def main() -> int:
+    if not REPORTS_DIR.exists():
+        print("No .test_reports directory found. Run tests first to generate reports.")
+        return 0
+
+    reports = load_reports()
+    if len(reports) < MIN_RUNS:
+        print(
+            f"Only {len(reports)} report(s) found; "
+            f"need at least {MIN_RUNS} runs for flaky detection."
+        )
+        return 0
+
+    outcome_flaky, duration_flaky = find_flaky_tests(reports)
+
+    if not outcome_flaky and not duration_flaky:
+        print(f"No flaky tests detected across {len(reports)} runs.")
+        return 0
+
+    exit_code = 0
+
+    if outcome_flaky:
+        exit_code = 1
+        print("=" * 60)
+        print("FLAKY TESTS DETECTED (outcome flips between runs):")
+        print("=" * 60)
+        for nodeid in outcome_flaky:
+            print(f"  {nodeid}")
+        print(
+            f"\n{len(outcome_flaky)} flaky test(s) found. "
+            f"Mark with @pytest.mark.flaky to quarantine, "
+            f"or fix the underlying cause."
+        )
+
+    if duration_flaky:
+        exit_code = 1
+        print()
+        print("=" * 60)
+        print("POTENTIALLY UNSTABLE TESTS (high duration variance):")
+        print("=" * 60)
+        for nodeid in duration_flaky:
+            print(f"  {nodeid}")
+        print(
+            f"\n{len(duration_flaky)} unstable test(s) found. "
+            f"These may depend on external resources or timing."
+        )
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-flaky-tests.py
+++ b/scripts/check-flaky-tests.py
@@ -18,6 +18,11 @@ from statistics import mean, stdev
 REPORTS_DIR = Path(".test_reports")
 MIN_RUNS = 3  # require at least this many runs to detect flakiness
 
+# Markers that indicate tests with inherent external-dependency variance.
+# These tests are excluded from duration-variance checks because their
+# timing depends on network, API keys, or tmux sessions rather than code stability.
+EXTERNAL_DEPENDENCY_MARKERS = {"integration", "tmux", "flaky"}
+
 
 def load_reports() -> list[dict]:
     """Load all archived JSON test reports sorted by timestamp."""
@@ -49,10 +54,17 @@ def detect_outcome_flaky(reports: list[dict]) -> list[str]:
 
 
 def detect_duration_flaky(reports: list[dict], coefficient_threshold: float = 0.5) -> list[str]:
-    """Find tests with high duration variance across runs (CV > threshold)."""
+    """Find tests with high duration variance across runs (CV > threshold).
+
+    Excludes tests marked integration, tmux, or flaky since their timing
+    inherently depends on external resources (API keys, tmux sessions).
+    """
     test_durations: dict[str, list[float]] = defaultdict(list)
     for report in reports:
         for test in report.get("tests", []):
+            keywords = set(test.get("keywords", []))
+            if keywords & EXTERNAL_DEPENDENCY_MARKERS:
+                continue
             duration = test.get("call", {}).get("duration", 0)
             if duration > 0:
                 test_durations[test["nodeid"]].append(duration)

--- a/src/tunacode/exceptions.py
+++ b/src/tunacode/exceptions.py
@@ -331,4 +331,3 @@ class ToolRetryError(TunaCodeError):
     def __init__(self, message: str, original_error: OriginalError = None):
         super().__init__(message)
         self.original_error = original_error
-

--- a/uv.lock
+++ b/uv.lock
@@ -221,17 +221,23 @@ sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
     { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
     { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
     { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
     { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
     { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
     { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
     { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
     { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
     { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
     { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
     { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
@@ -403,8 +409,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/49/498c86566a1d80e978b42f0d702795f69887005548c041636df6ae1ca64c/cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d", size = 4450807, upload-time = "2025-10-15T23:16:56.414Z" },
     { url = "https://files.pythonhosted.org/packages/4b/0a/863a3604112174c8624a2ac3c038662d9e59970c7f926acdcfaed8d61142/cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb", size = 4299615, upload-time = "2025-10-15T23:16:58.442Z" },
     { url = "https://files.pythonhosted.org/packages/64/02/b73a533f6b64a69f3cd3872acb6ebc12aef924d8d103133bb3ea750dc703/cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849", size = 4016800, upload-time = "2025-10-15T23:17:00.378Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d5/16e41afbfa450cde85a3b7ec599bebefaef16b5c6ba4ec49a3532336ed72/cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8", size = 4984707, upload-time = "2025-10-15T23:17:01.98Z" },
     { url = "https://files.pythonhosted.org/packages/c9/56/e7e69b427c3878352c2fb9b450bd0e19ed552753491d39d7d0a2f5226d41/cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec", size = 4482541, upload-time = "2025-10-15T23:17:04.078Z" },
     { url = "https://files.pythonhosted.org/packages/78/f6/50736d40d97e8483172f1bb6e698895b92a223dba513b0ca6f06b2365339/cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91", size = 4299464, upload-time = "2025-10-15T23:17:05.483Z" },
+    { url = "https://files.pythonhosted.org/packages/00/de/d8e26b1a855f19d9994a19c702fa2e93b0456beccbcfe437eda00e0701f2/cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e", size = 4950838, upload-time = "2025-10-15T23:17:07.425Z" },
     { url = "https://files.pythonhosted.org/packages/8f/29/798fc4ec461a1c9e9f735f2fc58741b0daae30688f41b2497dcbc9ed1355/cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926", size = 4481596, upload-time = "2025-10-15T23:17:09.343Z" },
     { url = "https://files.pythonhosted.org/packages/15/8d/03cd48b20a573adfff7652b76271078e3045b9f49387920e7f1f631d125e/cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71", size = 4426782, upload-time = "2025-10-15T23:17:11.22Z" },
     { url = "https://files.pythonhosted.org/packages/fa/b1/ebacbfe53317d55cf33165bda24c86523497a6881f339f9aae5c2e13e57b/cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac", size = 4698381, upload-time = "2025-10-15T23:17:12.829Z" },
@@ -412,8 +420,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/42/fa8389d4478368743e24e61eea78846a0006caffaf72ea24a15159215a14/cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d", size = 4440029, upload-time = "2025-10-15T23:17:49.837Z" },
     { url = "https://files.pythonhosted.org/packages/5f/eb/f483db0ec5ac040824f269e93dd2bd8a21ecd1027e77ad7bdf6914f2fd80/cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0", size = 4297222, upload-time = "2025-10-15T23:17:51.357Z" },
     { url = "https://files.pythonhosted.org/packages/fd/cf/da9502c4e1912cb1da3807ea3618a6829bee8207456fbbeebc361ec38ba3/cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc", size = 4012280, upload-time = "2025-10-15T23:17:52.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8f/9adb86b93330e0df8b3dcf03eae67c33ba89958fc2e03862ef1ac2b42465/cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3", size = 4978958, upload-time = "2025-10-15T23:17:54.965Z" },
     { url = "https://files.pythonhosted.org/packages/d1/a0/5fa77988289c34bdb9f913f5606ecc9ada1adb5ae870bd0d1054a7021cc4/cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971", size = 4473714, upload-time = "2025-10-15T23:17:56.754Z" },
     { url = "https://files.pythonhosted.org/packages/14/e5/fc82d72a58d41c393697aa18c9abe5ae1214ff6f2a5c18ac470f92777895/cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac", size = 4296970, upload-time = "2025-10-15T23:17:58.588Z" },
+    { url = "https://files.pythonhosted.org/packages/78/06/5663ed35438d0b09056973994f1aec467492b33bd31da36e468b01ec1097/cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04", size = 4940236, upload-time = "2025-10-15T23:18:00.897Z" },
     { url = "https://files.pythonhosted.org/packages/fc/59/873633f3f2dcd8a053b8dd1d38f783043b5fce589c0f6988bf55ef57e43e/cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506", size = 4472642, upload-time = "2025-10-15T23:18:02.749Z" },
     { url = "https://files.pythonhosted.org/packages/3d/39/8e71f3930e40f6877737d6f69248cf74d4e34b886a3967d32f919cc50d3b/cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963", size = 4423126, upload-time = "2025-10-15T23:18:04.85Z" },
     { url = "https://files.pythonhosted.org/packages/cd/c7/f65027c2810e14c3e7268353b1681932b87e5a48e65505d8cc17c99e36ae/cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4", size = 4686573, upload-time = "2025-10-15T23:18:06.908Z" },
@@ -1622,6 +1632,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2087,6 +2110,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-json-report" },
     { name = "pytest-randomly" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "textual-dev" },
@@ -2112,6 +2136,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-json-report" },
     { name = "pytest-randomly" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "textual-dev" },
@@ -2145,6 +2170,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-json-report", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15.0" },
+    { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=14" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1" },
     { name = "python-levenshtein", specifier = ">=0.21.0" },
     { name = "rich", specifier = ">=14.2.0,<15.0.0" },
@@ -2178,6 +2204,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-json-report", specifier = ">=1.5.0" },
     { name = "pytest-randomly", specifier = ">=3.15.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "ruff", specifier = "==0.14.9" },
     { name = "textual-dev" },


### PR DESCRIPTION
## Summary

Adds comprehensive flaky test detection to the test infrastructure:

### Changes

1. **`pytest-rerunfailures`** — Industry-standard plugin for retrying failed tests. Configured with `--reruns 2 --reruns-delay 1` in `pytest.ini`. Failed tests automatically retry before being reported as failures, preventing intermittent failures from blocking CI.

2. **`flaky` marker** — New pytest marker (`@pytest.mark.flaky`) for labeling known-unstable tests. Enables optional quarantine via `-m "not flaky"` in CI.

3. **`scripts/check-flaky-tests.py`** — Analyzes historical JSON test reports (from `pytest-json-report`) to detect:
   - **Outcome-flaky tests**: tests that flip between pass/fail across runs
   - **Duration-unstable tests**: tests with high coefficient of variation in execution time (excludes integration/tmux/flaky-marked tests, since their timing inherently depends on external resources)

4. **Pre-push hook integration** — The flaky test check runs on `git push`, surfacing unstable tests before they reach CI.

### Why this matters

- Prevents flaky tests from silently eroding confidence in the test suite
- Gives developers immediate feedback when a test becomes unstable
- Provides a clear quarantine path via the `flaky` marker
- Excludes integration/tmux tests from false-positive duration variance alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Exception Handling

- scripts/check-flaky-tests.py uses defensive exception handling when loading reports:
  ```python
  try:
      with open(path) as f:
          reports.append(json.load(f))
  except (json.JSONDecodeError, OSError):
      continue
  ```
  Corrupted or unreadable JSON report files are skipped, allowing processing to continue with valid reports. The script's main() also guards missing report directory and insufficient report count by printing a message and returning exit code 0 for non-critical conditions; it returns 1 only when unstable tests are detected to surface failures in CI/pre-push hooks.

- A tiny non-functional change in src/tunacode/exceptions.py removed an extra trailing blank line in ToolRetryError.__init__; no behavioral change to exception handling.

## Type Safety

- The new flaky-check script uses Python 3.x type annotations (e.g., list[dict], dict[str, list[float]], tuple[list[str], list[str]], int) and typed container usage (defaultdict[list]/set). These annotations improve readability and static analysis; no type-safety regressions were introduced.

## State Management, Messages, and Tool Calls

- No changes to application SessionState, message passing, or tool-call architectures.
- Tooling/config changes:
  - pytest-rerunfailures added to dev/test tooling (pyproject.toml), and pytest is configured via pytest.ini to retry failing tests (`--reruns 2 --reruns-delay 1`), which affects CI/test-run behavior by suppressing transient failures until retries are exhausted.
  - The script prints categorized lists of detected outcome-flaky and duration-unstable tests and returns exit codes to integrate with CI or git hooks.
  - The flaky-check script is integrated into a pre-push Git hook so developers receive local feedback about unstable tests before pushing.

## Dead Code

- No dead code added. The new script is purposeful and exercised via the hook/CI integration. The exceptions.py change removed only an extraneous blank line.

## Configuration Changes (summary)

- pytest.ini: Adds `--reruns 2 --reruns-delay 1` and a `flaky` marker for quarantining known-unstable tests (can be excluded with `-m "not flaky"` in CI).
- pyproject.toml: Adds `pytest-rerunfailures>=14` to dev dependencies and updates deptry ignore list for DEP002 to include pytest-rerunfailures.

## Other Notes

- The duration-unstable detection excludes integration, tmux, and tests already marked `flaky` to reduce false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->