### PR TITLE
refactor: move thinking panel state out of app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-04-27
+Last Updated: 2026-05-17
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.
@@ -61,7 +61,7 @@ Last Updated: 2026-04-27
   - Allowed import direction: `ui -> core -> tools`, with shared-layer imports from `utils`, `types`, `configuration`, `constants`, `exceptions`.
 - Import ordering test: `tests/architecture/test_import_order.py`.
   - Layer order constant includes shared modules (`configuration, constants, exceptions, prompts, skills, types, utils`) then layered modules (`tools, infrastructure, core, ui`).
-- Public-init constraint: `tests/architecture/test_init_bloat.py`.
+- Public-init constraint: `tests/architecture/test_imports_in_init.py`.
 - Dependency map regeneration pipeline: `scripts/grimp_layers_report.py`, committed to `docs/architecture/dependencies/` by workflow.
 
 ## Documentation Sources to Trust
@@ -98,7 +98,7 @@ Last Updated: 2026-04-27
   - `uv run pytest`
   - `uv run pytest tests/test_dependency_layers.py -v`
   - `uv run pytest tests/architecture/test_import_order.py`
-  - `uv run pytest tests/architecture/test_init_bloat.py`
+  - `uv run pytest tests/architecture/test_imports_in_init.py`
   - `uv run python scripts/run_gates.py`
   - `uv run python scripts/check_agents_freshness.py`
   - `uv run python scripts/generate_structure_tree.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-05-17
+Last Updated: 2026-05-18
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.

--- a/src/tunacode/exceptions.py
+++ b/src/tunacode/exceptions.py
@@ -331,4 +331,3 @@ class ToolRetryError(TunaCodeError):
     def __init__(self, message: str, original_error: OriginalError = None):
         super().__init__(message)
         self.original_error = original_error
-

--- a/src/tunacode/ui/app.py
+++ b/src/tunacode/ui/app.py
@@ -65,6 +65,8 @@ from tunacode.ui.slopgotchi import (
 )
 from tunacode.ui.streaming import StreamingHandler
 from tunacode.ui.styles import STYLE_PRIMARY, STYLE_SUCCESS, STYLE_WARNING
+from tunacode.ui.thinking_state import ThinkingState
+
 from tunacode.ui.widgets import (
     ChatContainer,
     CommandAutoComplete,
@@ -149,10 +151,9 @@ class TextualReplApp(App[None]):
         self._slopgotchi_timer: Timer | None = None
         self._request_bridge: RequestUiBridge | None = None
         self._delta_flush_timer: Timer | None = None
-
-        self._current_thinking_text: str = ""
-        self._last_thinking_update: float = 0.0
         self._last_editor_keypress_at: float = 0.0
+
+        self._thinking_state = ThinkingState(self)
         self._request_debug = RequestDebugTracer(self)
 
     def compose(self) -> ComposeResult:
@@ -298,7 +299,7 @@ class TextualReplApp(App[None]):
         thinking_callback_ms = 0.0
         if thinking_batch.has_data:
             thinking_started_at = time.monotonic()
-            await self._thinking_callback(thinking_batch.text)
+            await self._thinking_state.callback(thinking_batch.text)
             thinking_callback_ms = (
                 time.monotonic() - thinking_started_at
             ) * self.MILLISECONDS_PER_SECOND
@@ -326,7 +327,7 @@ class TextualReplApp(App[None]):
         if not self._loading_indicator_shown:
             self._request_debug.loading_shown(reason="request_start")
         self._show_loading_indicator()
-        self._clear_thinking_state()
+        self._thinking_state.clear()
         bridge = RequestUiBridge(self)
         self._request_bridge = bridge
         self._start_delta_flush_timer()
@@ -398,7 +399,7 @@ class TextualReplApp(App[None]):
             self._hide_loading_indicator()
             self.query_one("#viewport").remove_class(RICHLOG_CLASS_STREAMING)
             self.streaming.reset()
-            self._finalize_thinking_state_after_request()
+            self._thinking_state.finalize()
             self._update_compaction_status(False)
             response_panel_ms = 0.0
             response_char_count = 0
@@ -765,28 +766,3 @@ class TextualReplApp(App[None]):
         )
         if self._context_panel_visible:
             self._refresh_context_panel()
-
-    def _hide_thinking_output(self) -> None:
-        from tunacode.ui.thinking_state import hide_thinking_output
-
-        hide_thinking_output(self)
-
-    def _clear_thinking_state(self) -> None:
-        from tunacode.ui.thinking_state import clear_thinking_state
-
-        clear_thinking_state(self)
-
-    def _finalize_thinking_state_after_request(self) -> None:
-        from tunacode.ui.thinking_state import finalize_thinking_state_after_request
-
-        finalize_thinking_state_after_request(self)
-
-    def _refresh_thinking_output(self, force: bool = False) -> None:
-        from tunacode.ui.thinking_state import refresh_thinking_output
-
-        refresh_thinking_output(self, force)
-
-    async def _thinking_callback(self, delta: str) -> None:
-        from tunacode.ui.thinking_state import thinking_callback
-
-        await thinking_callback(self, delta)

--- a/src/tunacode/ui/commands/thoughts.py
+++ b/src/tunacode/ui/commands/thoughts.py
@@ -22,9 +22,9 @@ class ThoughtsCommand(Command):
         session.show_thoughts = not session.show_thoughts
 
         if session.show_thoughts:
-            app._refresh_thinking_output(force=True)
+            app._thinking_state.refresh(force=True)
             app.notify("Thought panel: ON")
             return
 
-        app._hide_thinking_output()
+        app._thinking_state.hide()
         app.notify("Thought panel: OFF")

--- a/src/tunacode/ui/thinking_state.py
+++ b/src/tunacode/ui/thinking_state.py
@@ -11,113 +11,112 @@ if TYPE_CHECKING:
     from tunacode.ui.app import TextualReplApp
 
 
-def _editor_has_draft(app: TextualReplApp) -> bool:
-    return bool(app.editor.value.strip())
+class ThinkingState:
+    """Encapsulates live thinking-panel state and rendering logic."""
 
+    def __init__(self, app: TextualReplApp) -> None:
+        self._app = app
+        self._text: str = ""
+        self._last_update: float = 0.0
 
-def _has_recent_editor_keypress(app: TextualReplApp) -> bool:
-    if not _editor_has_draft(app):
-        return False
-    last_keypress_at = app._last_editor_keypress_at
-    if last_keypress_at <= 0.0:
-        return False
-    elapsed_ms = (time.monotonic() - last_keypress_at) * app.MILLISECONDS_PER_SECOND
-    return elapsed_ms < app.THINKING_DEFER_AFTER_KEYPRESS_MS
+    @property
+    def _widget(self) -> Static | None:
+        widget = self._app._thinking_panel_widget
+        if widget is None:
+            return None
+        return widget
 
+    def _editor_has_draft(self) -> bool:
+        return bool(self._app.editor.value.strip())
 
-def _current_thinking_throttle_ms(app: TextualReplApp) -> float:
-    if _editor_has_draft(app):
-        return app.THINKING_THROTTLE_WHILE_DRAFTING_MS
-    return app.THINKING_THROTTLE_MS
+    def _has_recent_editor_keypress(self) -> bool:
+        if not self._editor_has_draft():
+            return False
+        last_keypress_at = self._app._last_editor_keypress_at
+        if last_keypress_at <= 0.0:
+            return False
+        elapsed_ms = (time.monotonic() - last_keypress_at) * self._app.MILLISECONDS_PER_SECOND
+        return elapsed_ms < self._app.THINKING_DEFER_AFTER_KEYPRESS_MS
 
+    def _throttle_ms(self) -> float:
+        if self._editor_has_draft():
+            return self._app.THINKING_THROTTLE_WHILE_DRAFTING_MS
+        return self._app.THINKING_THROTTLE_MS
 
-def _thinking_widget(app: TextualReplApp) -> Static | None:
-    widget = app._thinking_panel_widget
-    if widget is None:
-        return None
-    return widget
+    def hide(self) -> None:
+        """Hide the live thinking panel without removing the widget."""
+        widget = self._widget
+        if widget is None:
+            return
+        widget.update("")
+        widget.remove_class("active")
 
+    def clear(self) -> None:
+        """Reset thinking buffer and hide the widget."""
+        self._text = ""
+        self._last_update = 0.0
+        self.hide()
 
-def hide_thinking_output(app: TextualReplApp) -> None:
-    """Hide the live thinking panel without removing the widget."""
-    thinking_panel_widget = _thinking_widget(app)
-    if thinking_panel_widget is None:
-        return
-    thinking_panel_widget.update("")
-    thinking_panel_widget.remove_class("active")
+    def refresh(self, force: bool = False) -> None:
+        """Throttled render of the live thinking panel."""
+        if not self._app.state_manager.session.show_thoughts:
+            return
+        if not self._text:
+            self.hide()
+            return
 
+        widget = self._widget
+        if widget is None:
+            return
 
-def clear_thinking_state(app: TextualReplApp) -> None:
-    """Reset thinking buffer and hide the widget."""
-    app._current_thinking_text = ""
-    app._last_thinking_update = 0.0
-    hide_thinking_output(app)
+        if not force and self._has_recent_editor_keypress():
+            return
 
+        now = time.monotonic()
+        elapsed_ms = (now - self._last_update) * self._app.MILLISECONDS_PER_SECOND
+        if not force and elapsed_ms < self._throttle_ms():
+            return
 
-def finalize_thinking_state_after_request(app: TextualReplApp) -> None:
-    """After a request completes, persist a final thinking panel into chat history."""
-    if not app.state_manager.session.show_thoughts:
-        clear_thinking_state(app)
-        return
-    if not app._current_thinking_text:
-        hide_thinking_output(app)
-        return
+        from tunacode.ui.renderers.thinking import render_thinking_panel
 
-    from tunacode.ui.renderers.thinking import render_thinking_panel
+        self._last_update = now
+        content, meta = render_thinking_panel(
+            self._text,
+            max_lines=self._app.THINKING_MAX_RENDER_LINES,
+            max_chars=self._app.THINKING_MAX_RENDER_CHARS,
+        )
+        widget.border_title = meta.border_title
+        widget.border_subtitle = meta.border_subtitle
+        widget.update(content)
+        widget.add_class("active")
 
-    thinking_content, thinking_panel_meta = render_thinking_panel(
-        app._current_thinking_text,
-        max_lines=app.THINKING_MAX_RENDER_LINES,
-        max_chars=app.THINKING_MAX_RENDER_CHARS,
-    )
-    app.chat_container.write(thinking_content, expand=True, panel_meta=thinking_panel_meta)
-    clear_thinking_state(app)
+    def finalize(self) -> None:
+        """After a request completes, persist a final thinking panel into chat history."""
+        if not self._app.state_manager.session.show_thoughts:
+            self.clear()
+            return
+        if not self._text:
+            self.hide()
+            return
 
+        from tunacode.ui.renderers.thinking import render_thinking_panel
 
-def refresh_thinking_output(app: TextualReplApp, force: bool = False) -> None:
-    """Throttled render of the live thinking panel."""
-    if not app.state_manager.session.show_thoughts:
-        return
-    if not app._current_thinking_text:
-        hide_thinking_output(app)
-        return
+        content, meta = render_thinking_panel(
+            self._text,
+            max_lines=self._app.THINKING_MAX_RENDER_LINES,
+            max_chars=self._app.THINKING_MAX_RENDER_CHARS,
+        )
+        self._app.chat_container.write(content, expand=True, panel_meta=meta)
+        self.clear()
 
-    thinking_panel_widget = _thinking_widget(app)
-    if thinking_panel_widget is None:
-        return
+    async def callback(self, delta: str) -> None:
+        """Accumulate thinking text and refresh the panel."""
+        self._text += delta
+        overflow = len(self._text) - self._app.THINKING_BUFFER_CHAR_LIMIT
+        if overflow > 0:
+            self._text = self._text[overflow:]
 
-    now = time.monotonic()
-    elapsed_ms = (now - app._last_thinking_update) * app.MILLISECONDS_PER_SECOND
-    if not force and _has_recent_editor_keypress(app):
-        return
+        if not self._app.state_manager.session.show_thoughts:
+            return
 
-    thinking_throttle_ms = _current_thinking_throttle_ms(app)
-    if not force and elapsed_ms < thinking_throttle_ms:
-        return
-
-    from tunacode.ui.renderers.thinking import render_thinking_panel
-
-    app._last_thinking_update = now
-    thinking_content, thinking_panel_meta = render_thinking_panel(
-        app._current_thinking_text,
-        max_lines=app.THINKING_MAX_RENDER_LINES,
-        max_chars=app.THINKING_MAX_RENDER_CHARS,
-    )
-    thinking_panel_widget.border_title = thinking_panel_meta.border_title
-    thinking_panel_widget.border_subtitle = thinking_panel_meta.border_subtitle
-    thinking_panel_widget.update(thinking_content)
-    thinking_panel_widget.add_class("active")
-
-
-async def thinking_callback(app: TextualReplApp, delta: str) -> None:
-    """Accumulate thinking text and refresh the panel."""
-    app._current_thinking_text += delta
-    current_char_count = len(app._current_thinking_text)
-    overflow_char_count = current_char_count - app.THINKING_BUFFER_CHAR_LIMIT
-    if overflow_char_count > 0:
-        app._current_thinking_text = app._current_thinking_text[overflow_char_count:]
-
-    if not app.state_manager.session.show_thoughts:
-        return
-
-    refresh_thinking_output(app)
+        self.refresh()

--- a/src/tunacode/ui/thinking_state.py
+++ b/src/tunacode/ui/thinking_state.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from tunacode.ui.app import TextualReplApp
 
 
+THINKING_PANEL_HORIZONTAL_MARGIN = 2
+
+
 class ThinkingState:
     """Encapsulates live thinking-panel state and rendering logic."""
 
@@ -57,7 +60,7 @@ class ThinkingState:
         self._last_update = 0.0
         self.hide()
 
-    def refresh(self, force: bool = False) -> None:
+    def refresh(self, *, force: bool = False) -> None:
         """Throttled render of the live thinking panel."""
         if not self._app.state_manager.session.show_thoughts:
             return
@@ -90,6 +93,15 @@ class ThinkingState:
         widget.update(content)
         widget.add_class("active")
 
+    def _final_panel_width(self) -> int:
+        width_candidates = [
+            self._app.chat_container.content_region.width,
+            self._app.chat_container.size.width,
+            self._app.size.width,
+        ]
+        content_width = next((width for width in width_candidates if width > 0), 1)
+        return max(1, content_width - THINKING_PANEL_HORIZONTAL_MARGIN)
+
     def finalize(self) -> None:
         """After a request completes, persist a final thinking panel into chat history."""
         if not self._app.state_manager.session.show_thoughts:
@@ -106,7 +118,11 @@ class ThinkingState:
             max_lines=self._app.THINKING_MAX_RENDER_LINES,
             max_chars=self._app.THINKING_MAX_RENDER_CHARS,
         )
-        self._app.chat_container.write(content, expand=True, panel_meta=meta)
+        self._app.chat_container.write(
+            content,
+            width=self._final_panel_width(),
+            panel_meta=meta,
+        )
         self.clear()
 
     async def callback(self, delta: str) -> None:

--- a/src/tunacode/ui/widgets/chat.py
+++ b/src/tunacode/ui/widgets/chat.py
@@ -276,6 +276,7 @@ class ChatContainer(VerticalScroll):
         renderable: RenderableType | tuple[RenderableType, PanelMeta],
         *,
         expand: bool = False,
+        width: int | None = None,
         panel_meta: PanelMeta | None = None,
     ) -> CopyOnSelectStatic:
         """Append a renderable to the chat container.
@@ -285,6 +286,7 @@ class ChatContainer(VerticalScroll):
         Args:
             renderable: Rich renderable or ``(RenderableType, PanelMeta)`` tuple.
             expand: If True, widget expands to fill available width.
+            width: Optional explicit widget width in cells.
             panel_meta: Optional panel metadata for CSS-styled borders.
 
         Returns:
@@ -294,7 +296,9 @@ class ChatContainer(VerticalScroll):
 
         widget = CopyOnSelectStatic(panel_content)
         widget.add_class("chat-message")
-        if expand:
+        if width is not None:
+            widget.styles.width = max(1, width)
+        elif expand:
             widget.add_class("expand")
 
         if panel_meta is not None:

--- a/tests/unit/ui/test_request_threading.py
+++ b/tests/unit/ui/test_request_threading.py
@@ -52,6 +52,22 @@ class _FakeBridgeApp:
         return True
 
 
+class _FakeThinkingState:
+    def __init__(self) -> None:
+        self.chunks: list[str] = []
+        self.cleared = False
+        self.finalized = False
+
+    async def callback(self, chunk: str) -> None:
+        self.chunks.append(chunk)
+
+    def clear(self) -> None:
+        self.cleared = True
+
+    def finalize(self) -> None:
+        self.finalized = True
+
+
 class _FakeToolCallbackApp:
     def __init__(self) -> None:
         self.messages: list[object] = []
@@ -177,12 +193,8 @@ async def test_flush_timer_applies_queued_deltas_to_streaming_handler() -> None:
     app = TextualReplApp(state_manager=StateManager())
     app._request_bridge = RequestUiBridge(_FakeBridgeApp())
     app.streaming = _FakeStreamingHandler()  # type: ignore[assignment]
-    thinking_chunks: list[str] = []
-
-    async def _fake_thinking_callback(chunk: str) -> None:
-        thinking_chunks.append(chunk)
-
-    app._thinking_callback = _fake_thinking_callback  # type: ignore[method-assign]
+    thinking_state = _FakeThinkingState()
+    app._thinking_state = thinking_state  # type: ignore[assignment]
 
     await app._request_bridge.streaming_callback("hello")
     await app._request_bridge.streaming_callback(" world")
@@ -191,7 +203,7 @@ async def test_flush_timer_applies_queued_deltas_to_streaming_handler() -> None:
     await app._flush_request_deltas()
 
     assert app.streaming.chunks == ["hello world"]
-    assert thinking_chunks == ["trace data"]
+    assert thinking_state.chunks == ["trace data"]
 
 
 def test_escape_handler_cancels_worker_handle() -> None:
@@ -226,8 +238,7 @@ async def test_process_request_runs_in_worker_and_sets_current_request_handle() 
     app.set_interval = lambda *_args, **_kwargs: timer  # type: ignore[method-assign]
     app._show_loading_indicator = lambda: None  # type: ignore[method-assign]
     app._hide_loading_indicator = lambda: None  # type: ignore[method-assign]
-    app._clear_thinking_state = lambda: None  # type: ignore[method-assign]
-    app._finalize_thinking_state_after_request = lambda: None  # type: ignore[method-assign]
+    app._thinking_state = _FakeThinkingState()  # type: ignore[assignment]
     app._update_resource_bar = lambda: None  # type: ignore[method-assign]
     app._get_latest_response_text = lambda: None  # type: ignore[method-assign]
     app._update_compaction_status = compaction_updates.append  # type: ignore[method-assign]

--- a/tests/unit/ui/test_thinking_state.py
+++ b/tests/unit/ui/test_thinking_state.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import time
 from types import SimpleNamespace
 
-from tunacode.ui.thinking_state import (
-    finalize_thinking_state_after_request,
-    refresh_thinking_output,
-)
+from tunacode.ui.thinking_state import ThinkingState
 
 
 class _FakeThinkingWidget:
@@ -46,41 +43,41 @@ class _FakeApp:
     def __init__(self) -> None:
         self.state_manager = SimpleNamespace(session=SimpleNamespace(show_thoughts=True))
         self.editor = SimpleNamespace(value="draft")
-        self._current_thinking_text = "live thought"
-        self._last_thinking_update = 0.0
         self._last_editor_keypress_at = 0.0
         self._thinking_panel_widget = _FakeThinkingWidget()
         self.chat_container = _FakeChatContainer()
+        self._thinking_state = ThinkingState(self)
+        self._thinking_state._text = "live thought"
 
 
-def test_refresh_thinking_output_defers_incremental_update_while_user_is_actively_typing() -> None:
+def test_refresh_defers_incremental_update_while_user_is_actively_typing() -> None:
     app = _FakeApp()
-    app._last_thinking_update = time.monotonic() - 1.0
+    app._thinking_state._last_update = time.monotonic() - 1.0
     app._last_editor_keypress_at = time.monotonic()
 
-    refresh_thinking_output(app)
+    app._thinking_state.refresh()
 
     assert app._thinking_panel_widget.updates == []
 
 
-def test_refresh_thinking_output_force_bypasses_recent_keypress_deferral() -> None:
+def test_refresh_force_bypasses_recent_keypress_deferral() -> None:
     app = _FakeApp()
-    app._last_thinking_update = time.monotonic() - 1.0
+    app._thinking_state._last_update = time.monotonic() - 1.0
     app._last_editor_keypress_at = time.monotonic()
 
-    refresh_thinking_output(app, force=True)
+    app._thinking_state.refresh(force=True)
 
     assert len(app._thinking_panel_widget.updates) == 1
     assert "active" in app._thinking_panel_widget.classes
 
 
-def test_finalize_thinking_state_moves_final_thoughts_into_chat_history() -> None:
+def test_finalize_moves_final_thoughts_into_chat_history() -> None:
     app = _FakeApp()
 
-    finalize_thinking_state_after_request(app)
+    app._thinking_state.finalize()
 
     assert len(app.chat_container.calls) == 1
     _content, kwargs = app.chat_container.calls[0]
     assert kwargs["expand"] is True
-    assert app._current_thinking_text == ""
+    assert app._thinking_state._text == ""
     assert "active" not in app._thinking_panel_widget.classes

--- a/tests/unit/ui/test_thinking_state.py
+++ b/tests/unit/ui/test_thinking_state.py
@@ -26,6 +26,8 @@ class _FakeThinkingWidget:
 class _FakeChatContainer:
     def __init__(self) -> None:
         self.calls: list[tuple[object, dict[str, object]]] = []
+        self.content_region = SimpleNamespace(width=88)
+        self.size = SimpleNamespace(width=90)
 
     def write(self, content: object, **kwargs: object) -> None:
         self.calls.append((content, dict(kwargs)))
@@ -46,6 +48,7 @@ class _FakeApp:
         self._last_editor_keypress_at = 0.0
         self._thinking_panel_widget = _FakeThinkingWidget()
         self.chat_container = _FakeChatContainer()
+        self.size = SimpleNamespace(width=100)
         self._thinking_state = ThinkingState(self)
         self._thinking_state._text = "live thought"
 
@@ -78,6 +81,7 @@ def test_finalize_moves_final_thoughts_into_chat_history() -> None:
 
     assert len(app.chat_container.calls) == 1
     _content, kwargs = app.chat_container.calls[0]
-    assert kwargs["expand"] is True
+    assert kwargs["width"] == 86
+    assert "expand" not in kwargs
     assert app._thinking_state._text == ""
     assert "active" not in app._thinking_panel_widget.classes


### PR DESCRIPTION
## Summary

- Move live thinking-panel buffer and rendering behavior into `ThinkingState`.
- Reduce `TextualReplApp` by removing the old thinking wrapper methods and calling the state object directly.
- Update `/thoughts` and focused tests to use the class boundary.
- Refresh `AGENTS.md` metadata and correct the stale public-init test path.

## Validation

- `uv run ruff check src/tunacode/ui/app.py src/tunacode/ui/commands/thoughts.py src/tunacode/ui/thinking_state.py tests/unit/ui/test_thinking_state.py tests/unit/ui/test_request_threading.py`
- `uv run pytest tests/unit/core/test_thinking_stream_routing.py tests/unit/ui/test_thinking_state.py tests/unit/ui/test_request_threading.py -q`
- `uv run pytest tests/test_dependency_layers.py tests/architecture/test_import_order.py tests/architecture/test_imports_in_init.py -q`
- push hooks: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## State Management Changes

The thinking-panel state is fully encapsulated in a new ThinkingState class and removed from TextualReplApp instance fields and helper functions. ThinkingState holds:
- _text (str) — live thinking buffer
- _last_update (float) — last render timestamp

All live-thinking operations (accumulation, throttled refresh, hide/clear, finalization into chat) are now methods on ThinkingState and are gated by session.show_thoughts (checked in refresh(), finalize(), and callback()). TextualReplApp now owns a single attribute _thinking_state: ThinkingState and delegates thinking behavior to it. Tests and the /thoughts command were updated to interact with app._thinking_state.

Other state changes in call sites:
- ChatContainer.write() gained an optional width parameter used by ThinkingState.finalize() to compute and pass a final panel width when writing to chat history.

## Exception Handling

No new try/except handling was introduced in ThinkingState; the code uses defensive early returns for guards (missing widget, empty buffer, throttle deferral). Separately, several exception types were adjusted to retain original errors on the instance (e.g., ToolExecutionError, GitOperationError, FileOperationError set self.original_error), improving observability of underlying causes for higher-level errors. No new exception-handling control flow was added around thinking logic.

## Type Safety Improvements or Regressions

Improvements:
- Encapsulation of thinking state into a class improves type locality and signatures (async callback signature, typed properties).
- ThinkingState._widget explicitly narrows to Static | None.
- ChatContainer.write signature extended with width: int | None while preserving previous behavior; callers now pass a concrete width in finalize().

No obvious regressions in typing were introduced in the files inspected.

## Dead Code Added or Removed

Removed:
- Module-level thinking helpers (previous functions for hide/clear/refresh/finalize/callback and editor-throttle helpers) were removed from the thinking module and replaced by ThinkingState methods.
- The following private TextualReplApp methods and direct thinking-related fields were removed from app: _hide_thinking_output, _clear_thinking_state, _finalize_thinking_state_after_request, _refresh_thinking_output, _thinking_callback, and their related per-field state tracking.

Added/Consolidated:
- New class ThinkingState encapsulates all migrated behavior.
- Tests replaced previous ad-hoc thinking stubs with _FakeThinkingState or direct ThinkingState usage.

No new dead code appears to have been introduced; functionality was migrated and call sites updated to the new class boundary.

## Buffer/Throttling Behavior

ThinkingState.callback accumulates incoming deltas and enforces THINKING_BUFFER_CHAR_LIMIT by trimming left-side overflow (silent truncation). refresh() enforces throttling with separate throttle windows depending on whether the editor has a draft and defers updates while recent editor keypresses occurred unless forced. finalize() renders and writes a final panel to chat with a computed width and then clears internal state.

## Tests and Validation

Unit tests were updated to exercise ThinkingState directly and to stub the new class where needed (tests/unit/ui/test_thinking_state.py, tests/unit/ui/test_request_threading.py). CI validation listed in PR objectives (ruff, pytest runs and architecture checks) indicates the change set was exercised across relevant suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alchemiststudiosDOTai/tunacode/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->