### PR TITLE
fix(streaming): forward tool args on execution-end event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Last Updated: 2026-06-22
+Last Updated: 2026-07-10
 
 ## Repository Orientation
 - This is `tunacode-cli`, a terminal AI coding agent with a Textual UI and tiny-agent tool loop.

--- a/src/tunacode/core/agents/agent_components/agent_streaming.py
+++ b/src/tunacode/core/agents/agent_components/agent_streaming.py
@@ -202,6 +202,9 @@ class AgentStreamMixin:
         tool_call_id = event_obj.tool_call_id
         tool_name = event_obj.tool_name
         state.tool_start_times[tool_call_id] = time.perf_counter()
+        state.tool_args_by_call_id[tool_call_id] = (
+            event_obj.args if event_obj.args is not None else {}
+        )
         self._mark_tool_start_batch_state(state, tool_call_id=tool_call_id)
         if self.tool_start_callback is not None:
             self.tool_start_callback(tool_name)
@@ -219,6 +222,7 @@ class AgentStreamMixin:
         tool_call_id = event_obj.tool_call_id
         tool_name = event_obj.tool_name
         duration_ms = self._resolve_tool_duration_ms(state, tool_call_id=tool_call_id)
+        tool_args = state.tool_args_by_call_id.pop(tool_call_id, {})
         status = "failed" if event_obj.is_error else "completed"
 
         state.active_tool_call_ids.discard(tool_call_id)
@@ -230,7 +234,7 @@ class AgentStreamMixin:
         self.tool_result_callback(
             tool_name,
             status,
-            event_obj.args or {},
+            tool_args,
             event_obj.result,
             duration_ms,
         )
@@ -245,6 +249,8 @@ class AgentStreamMixin:
         baseline_message_count: int,
     ) -> bool:
         _ = (agent, baseline_message_count)
+        if event_obj.args is not None:
+            state.tool_args_by_call_id[event_obj.tool_call_id] = event_obj.args
         if self.tool_result_callback is None:
             return False
 
@@ -348,6 +354,7 @@ class AgentStreamMixin:
             runtime=runtime,
             baseline_message_count=baseline_message_count,
             tool_start_times={},
+            tool_args_by_call_id={},
             active_tool_call_ids=set(),
             batch_tool_call_ids=set(),
         )

--- a/src/tunacode/core/agents/agent_components/agent_streaming.py
+++ b/src/tunacode/core/agents/agent_components/agent_streaming.py
@@ -230,7 +230,7 @@ class AgentStreamMixin:
         self.tool_result_callback(
             tool_name,
             status,
-            {},
+            event_obj.args or {},
             event_obj.result,
             duration_ms,
         )

--- a/src/tunacode/core/agents/helpers.py
+++ b/src/tunacode/core/agents/helpers.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from tinyagent.agent_types import (
     AgentToolResult,
     AssistantMessage,
+    JsonObject,
     TextContent,
 )
 
@@ -29,6 +30,7 @@ class _TinyAgentStreamState:
     runtime: RuntimeState
     baseline_message_count: int
     tool_start_times: dict[str, float]
+    tool_args_by_call_id: dict[str, JsonObject]
     active_tool_call_ids: set[str]
     batch_tool_call_ids: set[str]
     last_assistant_message: AssistantMessage | None = None

--- a/tests/unit/core/test_agent_streaming_tool_args.py
+++ b/tests/unit/core/test_agent_streaming_tool_args.py
@@ -1,0 +1,59 @@
+"""Tests for tool arguments retained across tinyagent stream events."""
+
+from __future__ import annotations
+
+from tinyagent.agent import Agent
+from tinyagent.agent_types import ToolExecutionEndEvent, ToolExecutionStartEvent
+
+from tunacode.core.agents.helpers import _TinyAgentStreamState
+from tunacode.core.agents.main import RequestOrchestrator
+from tunacode.core.session import StateManager
+
+
+async def test_tool_end_uses_args_retained_from_start_event() -> None:
+    callback_calls: list[tuple[object, ...]] = []
+    state_manager = StateManager()
+    orchestrator = RequestOrchestrator(
+        message="test",
+        model="openai/gpt-4o",
+        state_manager=state_manager,
+        streaming_callback=None,
+        tool_result_callback=lambda *args: callback_calls.append(args),
+    )
+    state = _TinyAgentStreamState(
+        runtime=state_manager.session.runtime,
+        baseline_message_count=0,
+        tool_start_times={},
+        tool_args_by_call_id={},
+        active_tool_call_ids=set(),
+        batch_tool_call_ids=set(),
+    )
+    agent = Agent()
+
+    await orchestrator._handle_stream_tool_execution_start(
+        ToolExecutionStartEvent(
+            tool_call_id="call-1",
+            tool_name="read_file",
+            args={"filepath": "src/example.py"},
+        ),
+        agent=agent,
+        state=state,
+        baseline_message_count=0,
+    )
+    await orchestrator._handle_stream_tool_execution_end(
+        ToolExecutionEndEvent(
+            tool_call_id="call-1",
+            tool_name="read_file",
+        ),
+        agent=agent,
+        state=state,
+        baseline_message_count=0,
+    )
+
+    assert len(callback_calls) == 1
+    assert callback_calls[0][0:3] == (
+        "read_file",
+        "completed",
+        {"filepath": "src/example.py"},
+    )
+    assert state.tool_args_by_call_id == {}


### PR DESCRIPTION
## What

Retain each tool call's arguments from tinyagent's start/update events and pass
them to `tool_result_callback` when the execution-end event arrives.

## Why

`ToolExecutionEndEvent` in tiny-agent-os 1.2.28 does not define an `args`
attribute. The earlier direct `event_obj.args` implementation would therefore
raise `AttributeError`, while the original hardcoded `{}` caused completed tool
panels such as `read_file` to render without their filepath.

## Implementation

- Cache typed `JsonObject` arguments by tool-call ID on start events.
- Refresh cached arguments when an update event provides them.
- Pop and forward the cached arguments on the matching end event.
- Fall back to `{}` when an end event has no matching start/update event.
- Avoid `getattr` and direct access to an attribute absent from the end-event contract.

## Verification

- Added regression coverage for a start event followed by an end event without an `args` field.
- Core unit tests: 92 passed.
- Architecture tests: 138 passed.
- Mypy, repository pre-commit hooks, and GitHub CI passed.
