### PR TITLE
refactor: remove dead parallel abstraction from tool renderer subsystem

### DIFF
--- a/src/tunacode/ui/renderers/tools/__init__.py
+++ b/src/tunacode/ui/renderers/tools/__init__.py
@@ -5,33 +5,17 @@ All renderers implement a 4-zone layout with syntax highlighting:
 - Zone 2: Params (key-value parameter display)
 - Zone 3: Viewport (main content with syntax highlighting)
 - Zone 4: Status (truncation info, timing)
+
+Importing this package registers every renderer with the dispatch
+registry; look up renderers via get_renderer(tool_name).
 """
 
-from tunacode.ui.renderers.tools.base import (  # noqa: F401
-    BOX_HORIZONTAL,
-    SEPARATOR_WIDTH,
-    BaseToolRenderer,
-    RendererConfig,
-    RenderFunc,
-    ToolRendererProtocol,
-    get_renderer,
-    list_renderers,
-    pad_lines,
-    tool_renderer,
-    truncate_content,
-    truncate_line,
-)
+from tunacode.ui.renderers.tools.base import get_renderer  # noqa: F401
+
+# Imported for their registration side effect (@tool_renderer decorator).
 from tunacode.ui.renderers.tools.bash import render_bash  # noqa: F401
 from tunacode.ui.renderers.tools.discover import render_discover  # noqa: F401
 from tunacode.ui.renderers.tools.hashline_edit import render_hashline_edit  # noqa: F401
 from tunacode.ui.renderers.tools.read_file import render_read_file  # noqa: F401
-from tunacode.ui.renderers.tools.syntax_utils import (  # noqa: F401
-    EXTENSION_LEXERS,
-    SYNTAX_THEME,
-    detect_code_lexer,
-    get_color,
-    get_lexer,
-    syntax_or_text,
-)
 from tunacode.ui.renderers.tools.web_fetch import render_web_fetch  # noqa: F401
 from tunacode.ui.renderers.tools.write_file import render_write_file  # noqa: F401

--- a/src/tunacode/ui/renderers/tools/base.py
+++ b/src/tunacode/ui/renderers/tools/base.py
@@ -1,4 +1,4 @@
-"""Base class and protocol for tool renderers following NeXTSTEP UI principles.
+"""Base class for tool renderers following NeXTSTEP UI principles.
 
 All tool renderers implement a 4-zone layout pattern:
 - Zone 1: Header (tool name, status info)
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Generic, Protocol, TypeVar, runtime_checkable
+from typing import Generic, TypeVar
 
 from rich.console import Group, RenderableType
 from rich.text import Text
@@ -73,22 +73,6 @@ def truncate_content(
 
     truncated = lines[:max_lines]
     return "\n".join(truncated), max_lines, total
-
-
-def pad_lines(lines: list[str], min_lines: int = MIN_VIEWPORT_LINES) -> list[str]:
-    """Pad a list of lines to minimum height.
-
-    Args:
-        lines: List of content lines
-        min_lines: Minimum number of lines required
-
-    Returns:
-        Padded list with at least min_lines entries
-    """
-    result = list(lines)
-    while len(result) < min_lines:
-        result.append("")
-    return result
 
 
 def clamp_content_width(max_line_width: int, reserved_width: int) -> int:
@@ -172,15 +156,6 @@ def get_renderer(tool_name: str) -> RenderFunc | None:
     return _renderer_registry.get(tool_name)
 
 
-def list_renderers() -> list[str]:
-    """Get list of all registered tool renderer names.
-
-    Returns:
-        Sorted list of registered tool names
-    """
-    return sorted(_renderer_registry.keys())
-
-
 @dataclass
 class RendererConfig:
     """Configuration for a tool renderer."""
@@ -192,98 +167,6 @@ class RendererConfig:
 
 
 T = TypeVar("T")
-
-
-@runtime_checkable
-class ToolRendererProtocol(Protocol[T]):
-    """Protocol defining the interface for tool renderers.
-
-    Type parameter T is the parsed data type (e.g., BashData, ListDirData).
-    """
-
-    def parse_result(self, args: ToolArgs | None, result: str) -> T | None:
-        """Parse raw result string into structured data.
-
-        Args:
-            args: Tool arguments passed to the tool
-            result: Raw result string from tool execution
-
-        Returns:
-            Parsed data object, or None if parsing fails
-        """
-        ...
-
-    def build_header(self, data: T, duration_ms: float | None, max_line_width: int) -> Text:
-        """Build Zone 1: header with tool name and status info.
-
-        Args:
-            data: Parsed tool result data
-            duration_ms: Execution duration in milliseconds
-            max_line_width: Maximum line width for truncation
-
-        Returns:
-            Rich Text object for the header zone
-        """
-        ...
-
-    def build_params(self, data: T, max_line_width: int) -> Text | None:
-        """Build Zone 2: parameter key-value display.
-
-        Args:
-            data: Parsed tool result data
-            max_line_width: Maximum line width for truncation
-
-        Returns:
-            Rich Text object for params zone, or None if no params
-        """
-        ...
-
-    def build_viewport(self, data: T, max_line_width: int) -> RenderableType:
-        """Build Zone 3: main content viewport.
-
-        Args:
-            data: Parsed tool result data
-            max_line_width: Maximum line width for truncation
-
-        Returns:
-            Rich renderable for the viewport zone
-        """
-        ...
-
-    def build_status(self, data: T, duration_ms: float | None, max_line_width: int) -> Text:
-        """Build Zone 4: status line with truncation info and timing.
-
-        Args:
-            data: Parsed tool result data
-            duration_ms: Execution duration in milliseconds
-            max_line_width: Maximum line width for truncation
-
-        Returns:
-            Rich Text object for the status zone
-        """
-        ...
-
-    def get_border_color(self, data: T) -> str:
-        """Determine panel border color based on result state.
-
-        Args:
-            data: Parsed tool result data
-
-        Returns:
-            Color string for the panel border
-        """
-        ...
-
-    def get_status_text(self, data: T) -> str:
-        """Get status text for panel title (e.g., 'done', 'exit 1').
-
-        Args:
-            data: Parsed tool result data
-
-        Returns:
-            Status text string
-        """
-        ...
 
 
 class BaseToolRenderer(ABC, Generic[T]):


### PR DESCRIPTION
## Description
Removes a dead parallel abstraction layer from `src/tunacode/ui/renderers/tools/` (net −133 lines, no behavior change):

- **`ToolRendererProtocol`** (~90 lines in `base.py`): a `runtime_checkable` Protocol that duplicated the `BaseToolRenderer` ABC method-for-method, docstrings included. All six renderers subclass the ABC; the Protocol was never used as a type annotation, isinstance check, or generic bound anywhere in `src`, `tests`, or `scripts` — it was a second copy of the same seven-method interface to keep in sync for no benefit.
- **`pad_lines`**: free function duplicating `BaseToolRenderer.pad_viewport_lines` line-for-line, zero callers.
- **`list_renderers`**: zero callers.
- **Package `__init__.py` re-export surface**: previously re-exported 13 symbols under `# noqa: F401`, but external code only imports `get_renderer` (in `panels.py`) and `render_bash` (directly from its submodule). The init now exports `get_renderer` plus the six submodule imports whose side effect registers each renderer, with a docstring explaining the registration mechanism.

Every removed symbol was verified dead via repo-wide grep (zero usages outside its definition site) before deletion.

## Pre-PR Checklist
- [x] **Rebased onto master** (`git fetch origin && git rebase origin/master`)
- [x] **All pre-commit hooks pass** (`uv run pre-commit run --all-files`)
- [ ] Tech debt baseline updated — N/A, no TODO/FIXME markers added

## Type of Change
- [x] Refactoring (code improvement without changing functionality)

## Testing
- [x] All existing tests pass (`uv run pytest`) — 325 passed, 2 skipped
- [ ] New tests have been added to cover the changes — N/A, deletion of verified-dead code only
- [x] Tests have been run locally
- [ ] Golden/character tests established for new features — N/A

### Test Coverage
- Deletion-only change; also verified at runtime that all six renderers still register through the dispatch registry (`get_renderer` returns a renderer for `bash`, `discover`, `hashline_edit`, `read_file`, `web_fetch`, `write_file`).

## Pre-commit Checks
- [x] All pre-commit hooks pass
- [x] Code formatted with `ruff format`
- [x] Code passes `ruff check` without warnings
- [x] No non-test Python file exceeds **600 lines**

## Checklist
- [x] My code follows the Python coding standards (type hints, f-strings, pathlib, etc.)
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] I have updated documentation in `@documentation/` and `.claude/` directories — N/A, removed symbols are not documented there
- [x] My changes generate no new warnings
- [x] Dependencies are properly managed in `pyproject.toml` — no dependency changes
- [x] Any dependent changes have been merged and published — none
- [x] Created rollback point with clear commit message before changes

## Documentation Updates
- [ ] Updated relevant files in `@documentation/` — N/A
- [ ] Updated developer notes in `.claude/` — N/A
- [ ] README.md updated (if needed) — N/A

## Additional Notes
Audit also surfaced six exception classes in `src/tunacode/exceptions.py` with zero references (`StateError`, `ServiceError`, `GitOperationError`, `ModelConfigurationError`, `SetupValidationError`, `ToolBatchingJSONError`, ~70 lines) — left out of this PR to keep it a single focused change; can follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HF5Lg9K7LhXLFstq2CKkKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HF5Lg9K7LhXLFstq2CKkKq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Simplified tool renderer registration and reduced package-level exports to `get_renderer` and renderer imports needed for registration.
- Removed unused `ToolRendererProtocol`, `pad_lines`, and `list_renderers` abstractions.
- Documented the renderer registration mechanism.
- No changes to session state, messages, tool-call handling, or exception paths.
- Reduced unused typing abstractions without affecting the existing registry or renderer behavior.
- Confirmed all six renderers remain registered; tests and quality checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->